### PR TITLE
Sanitize generated code names

### DIFF
--- a/src/Lamar/IoC/Instances/Instance.cs
+++ b/src/Lamar/IoC/Instances/Instance.cs
@@ -250,7 +250,7 @@ namespace Lamar.IoC.Instances
                 parent = parent.Parent;
             }
 
-            return "func_" + name;
+            return "func_" + name.Sanitize();
         }
     }
 }


### PR DESCRIPTION
Project was failing because the generated code was outputting this.
```
public System.Func<System.IServiceProvider, object> func_IConfigureOptions<Microsoft.AspNetCore.Mvc.MvcViewOptions> {get; set;}
```