### PR TITLE
Correcting some sample code used in the documentation

### DIFF
--- a/src/StructureMap.Testing/Acceptance/basic_registrations.cs
+++ b/src/StructureMap.Testing/Acceptance/basic_registrations.cs
@@ -20,7 +20,7 @@ namespace StructureMap.Testing.Acceptance
 
     /*
     // SAMPLE: SettingDefaults
-    public class SettingDefaults : Registry
+    public class SettingDefaults : ServiceRegistry
     {
         public SettingDefaults()
         {
@@ -53,7 +53,7 @@ namespace StructureMap.Testing.Acceptance
     }
     // ENDSAMPLE
     // SAMPLE: AdditionalRegistrations
-    public class AdditionalRegistrations : Registry
+    public class AdditionalRegistrations : ServiceRegistry
     {
         public AdditionalRegistrations()
         {

--- a/src/StructureMap.Testing/Configuration/DSL/RegistryTester.cs
+++ b/src/StructureMap.Testing/Configuration/DSL/RegistryTester.cs
@@ -33,7 +33,7 @@ namespace StructureMap.Testing.Configuration.DSL
         }
 
         // SAMPLE: simple-registry
-        public class PurpleRegistry : Registry
+        public class PurpleRegistry : ServiceRegistry
         {
             public PurpleRegistry()
             {


### PR DESCRIPTION
This is just a minor update that fixes the documentation samples which currently show registration samples that use the old StructureMap `Registry` class rather than Lamar's `ServiceRegistry`.