### PR TITLE
Transient instances created by lambda functions are not properly registered for disposal

### DIFF
--- a/src/Lamar.Testing/IoC/Acceptance/disposing_container.cs
+++ b/src/Lamar.Testing/IoC/Acceptance/disposing_container.cs
@@ -165,6 +165,20 @@ namespace StructureMap.Testing.Pipeline
 
             disposable.WasDisposed.ShouldBeTrue();
         }
+
+        [Fact]
+        public void should_dispose_lambda_instance_with_transient_scope()
+        {
+            var container = new Container(x => { x.For<I1>().Use(_ => new C1Yes()).Transient(); });
+            var nestedContainer = container.GetNestedContainer();
+            
+            var disposable = nestedContainer.GetInstance<I1>().ShouldBeOfType<C1Yes>();
+            disposable.WasDisposed.ShouldBeFalse();
+
+            container.Dispose();
+
+            disposable.WasDisposed.ShouldBeTrue();
+        }
     }
 
     public class Disposable : IDisposable

--- a/src/Lamar/IoC/Instances/InlineLambdaCreationFrame.cs
+++ b/src/Lamar/IoC/Instances/InlineLambdaCreationFrame.cs
@@ -25,7 +25,7 @@ namespace Lamar.IoC.Instances
         {
             writer.Write($"var {Variable.Usage} = ({Variable.VariableType.FullNameInCode()}){_setter.Usage}(({typeof(TContainer).FullNameInCode()}){_scope.Usage});");
 
-            if(!Variable.VariableType.IsPrimitive && Variable.VariableType != typeof(string))
+            if(!Variable.VariableType.IsPrimitive && !Variable.VariableType.IsEnum && Variable.VariableType != typeof(string))
             {
                 writer.Write($"var {Variable.Usage}_disposable = {Variable.Usage} as System.IDisposable;");
                 writer.Write($"if({Variable.Usage}_disposable != null) {{");

--- a/src/Lamar/IoC/Instances/InlineLambdaCreationFrame.cs
+++ b/src/Lamar/IoC/Instances/InlineLambdaCreationFrame.cs
@@ -24,6 +24,11 @@ namespace Lamar.IoC.Instances
         public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
         {
             writer.Write($"var {Variable.Usage} = ({Variable.VariableType.FullNameInCode()}){_setter.Usage}(({typeof(TContainer).FullNameInCode()}){_scope.Usage});");
+            writer.Write($"var {Variable.Usage}_disposable = {Variable.Usage} as System.IDisposable;");
+            writer.Write($"if({Variable.Usage}_disposable != null) {{");
+            writer.Write($"   {_scope.Usage}.Disposables.Add({Variable.Usage}_disposable);");
+            writer.Write("}");
+
             Next?.GenerateCode(method, writer);
         }
 

--- a/src/Lamar/IoC/Instances/InlineLambdaCreationFrame.cs
+++ b/src/Lamar/IoC/Instances/InlineLambdaCreationFrame.cs
@@ -24,10 +24,14 @@ namespace Lamar.IoC.Instances
         public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
         {
             writer.Write($"var {Variable.Usage} = ({Variable.VariableType.FullNameInCode()}){_setter.Usage}(({typeof(TContainer).FullNameInCode()}){_scope.Usage});");
-            writer.Write($"var {Variable.Usage}_disposable = {Variable.Usage} as System.IDisposable;");
-            writer.Write($"if({Variable.Usage}_disposable != null) {{");
-            writer.Write($"   {_scope.Usage}.Disposables.Add({Variable.Usage}_disposable);");
-            writer.Write("}");
+
+            if(!Variable.VariableType.IsPrimitive && Variable.VariableType != typeof(string))
+            {
+                writer.Write($"var {Variable.Usage}_disposable = {Variable.Usage} as System.IDisposable;");
+                writer.Write($"if({Variable.Usage}_disposable != null) {{");
+                writer.Write($"   {_scope.Usage}.Disposables.Add({Variable.Usage}_disposable);");
+                writer.Write("}");
+            }
 
             Next?.GenerateCode(method, writer);
         }


### PR DESCRIPTION
This is a recreation of the fix I generated for #71 and then accidentally erased. :)