### PR TITLE
try show different behavior from structuremap when configuring aspnet core container

### DIFF
--- a/src/Lamar.AspNetCoreTests/FailingConfigureContainer.cs
+++ b/src/Lamar.AspNetCoreTests/FailingConfigureContainer.cs
@@ -1,0 +1,79 @@
+using System;
+using Lamar;
+using Lamar.Microsoft.DependencyInjection;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using StructureMap;
+using StructureMap.AspNetCore;
+using Xunit;
+
+namespace Lamar.Testing.AspNetCoreIntegration
+{
+    public class FailingConfigureContainer
+    {
+        [Fact]
+        public void lamar_in_app_configure_container_uses_decorator()
+        {
+            var builder = new WebHostBuilder()
+                .UseKestrel()
+                .UseLamar()
+                .UseStartup<FailingStartupLamar>();
+            
+            //FAILING TEST
+            Assert.ThrowsAny<Exception>(() => builder.Start());
+        }
+
+        [Fact]
+        public void structuremap_in_app_configure_container_uses_decorator()
+        {
+            var builder = new WebHostBuilder()
+                .UseKestrel()
+                .UseStructureMap()
+                .UseStartup<FailingStartupStructuremap>();
+
+            Assert.ThrowsAny<Exception>(() => builder.Start());
+        }
+    }
+
+    public class FailingStartupLamar
+    {
+        public void ConfigureContainer(ServiceRegistry registry)
+        {
+            registry.For(typeof(IOptionsFactory<>)).DecorateAllWith(typeof(OptionsFactoryDecorator<>));
+        }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddOptions();
+            services.AddMvc();
+        }
+
+        public void Configure(IApplicationBuilder app) => app.UseMvc();
+    }
+
+    public class FailingStartupStructuremap
+    {
+        public void ConfigureContainer(Registry registry)
+        {
+            registry.For(typeof(IOptionsFactory<>)).DecorateAllWith(typeof(OptionsFactoryDecorator<>));
+        }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddOptions();
+            services.AddMvc();
+        }
+
+        public void Configure(IApplicationBuilder app) => app.UseMvc();
+    }
+
+    public class OptionsFactoryDecorator<T> : IOptionsFactory<T> where T : class, new()
+    {
+        public T Create(string name)
+        {
+            throw new Exception("This exception should be thrown any time some one tries to access IOptions<>");
+        }
+    }
+}

--- a/src/Lamar.AspNetCoreTests/FailingConfigureContainer.cs
+++ b/src/Lamar.AspNetCoreTests/FailingConfigureContainer.cs
@@ -21,7 +21,7 @@ namespace Lamar.Testing.AspNetCoreIntegration
                 .UseLamar()
                 .UseStartup<FailingStartupLamar>();
             
-            //FAILING TEST
+            //FAILING TEST : Does not throw when using Lamar
             Assert.ThrowsAny<Exception>(() => builder.Start());
         }
 
@@ -32,7 +32,8 @@ namespace Lamar.Testing.AspNetCoreIntegration
                 .UseKestrel()
                 .UseStructureMap()
                 .UseStartup<FailingStartupStructuremap>();
-
+            
+            //PASSING TEST : Correctly throws when using StructureMap as it is using the below OptionsFactoryDecorator
             Assert.ThrowsAny<Exception>(() => builder.Start());
         }
     }

--- a/src/Lamar.AspNetCoreTests/Lamar.AspNetCoreTests.csproj
+++ b/src/Lamar.AspNetCoreTests/Lamar.AspNetCoreTests.csproj
@@ -13,6 +13,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <!-- Just added to show that a test works for structuremap     -->
+    <PackageReference Include="StructureMap.AspNetCore" Version="1.4.0" /> 
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Lamar.Microsoft.DependencyInjection\Lamar.Microsoft.DependencyInjection.csproj" />


### PR DESCRIPTION
Adding a decorator is ConfigureContainer takes effect for structuremap but not for lamar. This pull request should not be merged as it adds structuremap dependency, but I wanted to leave it in there to show different behavior.