### PR TITLE
diagnostics: add aspnet core example

### DIFF
--- a/documentation/documentation/ioc/diagnostics/whatdoihave.md
+++ b/documentation/documentation/ioc/diagnostics/whatdoihave.md
@@ -22,3 +22,9 @@ If you're curious, all the raw code for this example is in [here](https://github
 Filtering the `WhatDoIHave()` results can be done in these ways:
 
 <[sample:whatdoihave-filtering]>
+
+## WhatDoIHave() under ASP.Net Core
+
+You can call `WhatDoIHave()` and `WhatDidIScan()` when running in ASP.Net Core like so:
+
+<[sample:whatdoihave-aspnetcore]>

--- a/src/Lamar.AspNetCoreTests/Samples/StartUp.cs
+++ b/src/Lamar.AspNetCoreTests/Samples/StartUp.cs
@@ -1,7 +1,9 @@
-﻿using Lamar.Microsoft.DependencyInjection;
+﻿using System;
+using Lamar.Microsoft.DependencyInjection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Lamar.Testing.AspNetCoreIntegration.Samples
 {
@@ -53,6 +55,42 @@ namespace Lamar.Testing.AspNetCoreIntegration.Samples
 
         public void Configure(IApplicationBuilder app)
         {
+            app.UseMvc();
+        }
+    }
+    // ENDSAMPLE
+
+    // SAMPLE: whatdoihave-aspnetcore
+    public class StartupWithDiagnostics
+    {
+        // Take in Lamar's ServiceRegistry instead of IServiceCollection
+        // as your argument, but fear not, it implements IServiceCollection
+        // as well
+        public void ConfigureContainer(ServiceRegistry services)
+        {
+            // Supports ASP.Net Core DI abstractions
+            services.AddMvc();
+            services.AddLogging();
+
+            // Also exposes Lamar specific registrations
+            // and functionality
+            services.Scan(s =>
+            {
+                s.TheCallingAssembly();
+                s.WithDefaultConventions();
+            });
+        }
+
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            if(env.IsDevelopment())
+            {
+                var container = (IContainer)app.ApplicationServices;
+                // or write to your own Logger
+                Console.WriteLine(container.WhatDidIScan());
+                Console.WriteLine(container.WhatDoIHave());
+            }
+
             app.UseMvc();
         }
     }


### PR DESCRIPTION
Small addition to the documentation to show how to call `WhatDidIScan()` and `WhatDoIHave()` when running in ASP.Net core, based off @CodingGorilla's [comment here](https://github.com/JasperFx/lamar/issues/98#issuecomment-431919398)