### PR TITLE
Fix Insecure Content Blocked

### DIFF
--- a/documentation/layout.htm
+++ b/documentation/layout.htm
@@ -104,8 +104,8 @@
 
 
     <footer>
-        <script type='text/javascript' src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-        <script type='text/javascript' src="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
+        <script type='text/javascript' src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+        <script type='text/javascript' src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 
         <[script:content/prism.js]>
         <[script:content/sidebar.js]>


### PR DESCRIPTION
Currently the search does not work in Chrome as some scripts are loaded via http and not https. Changed to just use // this means that they will use whatever protocol the page is using to load the scripts.