### PR TITLE
Autofac support

### DIFF
--- a/Lamar.sln
+++ b/Lamar.sln
@@ -53,6 +53,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LamarCodeGeneration", "src\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lamar.AutoFactory", "src\Lamar.AutoFactory\Lamar.AutoFactory.csproj", "{2250C640-88AF-4DA5-A1D1-7BC3717E1D60}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lamar.AutoFactory.Testing", "src\Lamar.AutoFactory.Testing\Lamar.AutoFactory.Testing.csproj", "{EFB244CD-F185-4052-A4B5-4A869682D616}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -151,6 +153,10 @@ Global
 		{2250C640-88AF-4DA5-A1D1-7BC3717E1D60}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2250C640-88AF-4DA5-A1D1-7BC3717E1D60}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2250C640-88AF-4DA5-A1D1-7BC3717E1D60}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EFB244CD-F185-4052-A4B5-4A869682D616}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EFB244CD-F185-4052-A4B5-4A869682D616}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EFB244CD-F185-4052-A4B5-4A869682D616}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EFB244CD-F185-4052-A4B5-4A869682D616}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Lamar.sln
+++ b/Lamar.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2036
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28803.202
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lamar.Testing", "src\Lamar.Testing\Lamar.Testing.csproj", "{865C14C3-4B54-46EC-B394-9BAD73905086}"
 EndProject
@@ -41,15 +41,17 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UserApp", "src\UserApp\User
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Bug-124-Widgets", "Bug-124-Widgets", "{317DED50-F632-48EB-8E02-E1B6739B35E1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Widget.Aspect.Logger", "src\Aspect.Logger\Widget.Aspect.Logger.csproj", "{A367AE1C-B39D-438B-BADD-3B7E368DDF97}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Widget.Aspect.Logger", "src\Aspect.Logger\Widget.Aspect.Logger.csproj", "{A367AE1C-B39D-438B-BADD-3B7E368DDF97}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Widget.Instance", "Widget.Instance\Widget.Instance.csproj", "{6F721733-9012-4434-A830-2F5E9A6A926B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Widget.Instance", "Widget.Instance\Widget.Instance.csproj", "{6F721733-9012-4434-A830-2F5E9A6A926B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Widget.Core", "Widget.Core\Widget.Core.csproj", "{178C596D-65D9-42F9-927C-DF63F348DCA5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Widget.Core", "Widget.Core\Widget.Core.csproj", "{178C596D-65D9-42F9-927C-DF63F348DCA5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Widget.Registration", "Widget.Registration\Widget.Registration.csproj", "{39F01E1B-0549-422A-A60F-747C1CDF0C08}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Widget.Registration", "Widget.Registration\Widget.Registration.csproj", "{39F01E1B-0549-422A-A60F-747C1CDF0C08}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LamarCodeGeneration", "src\LamarCodeGeneration\LamarCodeGeneration.csproj", "{2030BA2A-5D44-4BDA-9EF7-7EB0BC7A1C6F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LamarCodeGeneration", "src\LamarCodeGeneration\LamarCodeGeneration.csproj", "{2030BA2A-5D44-4BDA-9EF7-7EB0BC7A1C6F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lamar.AutoFactory", "src\Lamar.AutoFactory\Lamar.AutoFactory.csproj", "{2250C640-88AF-4DA5-A1D1-7BC3717E1D60}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -145,6 +147,10 @@ Global
 		{2030BA2A-5D44-4BDA-9EF7-7EB0BC7A1C6F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2030BA2A-5D44-4BDA-9EF7-7EB0BC7A1C6F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2030BA2A-5D44-4BDA-9EF7-7EB0BC7A1C6F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2250C640-88AF-4DA5-A1D1-7BC3717E1D60}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2250C640-88AF-4DA5-A1D1-7BC3717E1D60}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2250C640-88AF-4DA5-A1D1-7BC3717E1D60}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2250C640-88AF-4DA5-A1D1-7BC3717E1D60}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Lamar.AutoFactory.Testing/AutoFactoryTester.cs
+++ b/src/Lamar.AutoFactory.Testing/AutoFactoryTester.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Collections.Generic;
+using Shouldly;
+using Xunit;
+
+namespace Lamar.AutoFactory.Testing
+{
+    public class AutoFactoryTester
+    {
+        private Container container;
+
+        public AutoFactoryTester()
+        {
+        }
+
+        [Fact]
+        public void Can_build_the_factory()
+        {
+            container = new Container(cfg =>
+            {
+                cfg.For<IDummyService>().Use<DummyService>();
+                cfg.For<IDummyFactory>().CreateFactory();
+            });
+
+            var factory = container.GetInstance<IDummyFactory>();
+
+            factory.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void Can_resolve_component()
+        {
+            container = new Container(cfg =>
+            {
+                cfg.For<IDummyService>().Use<DummyService>();
+                cfg.For<IDummyFactory>().CreateFactory();
+            });
+
+            var factory = container.GetInstance<IDummyFactory>();
+
+            var component = factory.CreateDummyService();
+
+            component.ShouldNotBeNull();
+            component.ShouldBeOfType<DummyService>();
+        }
+
+        [Fact]
+        public void Can_resolve_generic_components_via_a_generic_method()
+        {
+            container = new Container(cfg =>
+            {
+                cfg.For<IDummyService>().Use<DummyService>();
+                cfg.For<IDummyFactory>().CreateFactory();
+            });
+
+            var factory = container.GetInstance<IDummyFactory>();
+
+            var component = factory.CreateService<IDummyService>();
+
+            component.ShouldNotBeNull();
+            component.ShouldBeOfType<DummyService>();
+        }
+
+        [Fact]
+        public void Can_resolve_a_closed_generic_return_type()
+        {
+            container = new Container(cfg =>
+            {
+                cfg.For<IHandler<Message>>().Use<MessageHandler>();
+                cfg.For<IDummyFactory>().CreateFactory();
+            });
+
+            var factory = container.GetInstance<IDummyFactory>();
+
+            var component = factory.CreateHandler<Message>();
+
+            component.ShouldNotBeNull();
+            component.ShouldBeOfType<MessageHandler>();
+        }
+
+        [Fact]
+        public void ResolveServiceWithRedundantExplicitArguments()
+        {
+            container = new Container(cfg =>
+            {
+                cfg.For<IDummyService>().Use<DummyService>();
+                cfg.For<IDummyFactory>().CreateFactory();
+            });
+
+            var factory = container.GetInstance<IDummyFactory>();
+
+            var component = factory.CreateDummyService("John", "Smith");
+
+            component.ShouldSatisfyAllConditions(
+                () => component.ShouldNotBeNull(),
+                () => component.ShouldBeOfType<DummyService>(),
+                () => component.Name.ShouldBeNull()
+            );
+        }
+
+        [Fact]
+        public void TryToResolveNotRegisteredNamedService()
+        {
+            container = new Container(cfg =>
+            {
+                cfg.For<IDummyService>().Use<DummyService>();
+                cfg.For<IDummyService>().Add<DummyServiceWithName>().Named("direct");
+                cfg.For<IDummyService>().Add<DummyServiceWithReversedName>().Named("reversed");
+                cfg.For<IDummyFactory>().CreateFactory();
+            });
+
+            var factory = container.GetInstance<IDummyFactory>();
+
+            var component = factory.GetNamedDummyService("unknown", "John", "Smith");
+
+            component.ShouldBeNull();
+        }
+
+        [Fact]
+        public void ResolveServiceNames()
+        {
+            container = new Container(cfg =>
+            {
+                cfg.For<IDummyService>().Use<DummyService>();
+                cfg.For<IDummyService>().Add<DummyServiceWithName>().Named("direct");
+                cfg.For<IDummyService>().Add<DummyServiceWithReversedName>().Named("reversed");
+                cfg.For<IDummyFactory>().CreateFactory();
+            });
+
+            var factory = container.GetInstance<IDummyFactory>();
+
+            var names = factory.GetNames<IDummyService>();
+
+            names.ShouldBe(new[] { string.Empty, "direct", "reversed" }, true);
+        }
+    }
+
+    public interface IHandler<T>
+    {
+        void Handle(T thing);
+    }
+
+    public class Message
+    {
+    }
+
+    public class MessageHandler : IHandler<Message>
+    {
+        public void Handle(Message thing)
+        {
+        }
+    }
+
+    // SAMPLE: IDummyService
+    public interface IDummyService
+    {
+        string Name { get; }
+    }
+
+    // ENDSAMPLE
+
+    // SAMPLE: DummyService
+    public class DummyService : IDummyService
+    {
+        public string Name { get; set; }
+    }
+
+    // ENDSAMPLE
+
+    public class DummyServiceWithName : IDummyService
+    {
+        public DummyServiceWithName(string namePart1, string namePart2)
+        {
+            Name = string.Format("{0} {1}", namePart1, namePart2);
+        }
+
+        public string Name { get; set; }
+    }
+
+    public class DummyServiceWithReversedName : IDummyService
+    {
+        public DummyServiceWithReversedName(string namePart1, string namePart2)
+        {
+            Name = string.Format("{0} {1}", namePart2, namePart1);
+        }
+
+        public string Name { get; set; }
+    }
+
+    // SAMPLE: IDummyFactory
+    public interface IDummyFactory
+    {
+        // This method will return the names of all registered implementations of TService.
+        IList<string> GetNames<TService>();
+
+        // This method will just create the default IDummyService implementation.
+        IDummyService CreateDummyService();
+
+        // This method will just create the default IDummyService implementation and pass namePart1 and namePart2 as
+        // dependencies.
+        IDummyService CreateDummyService(string namePart1, string namePart2);
+
+        // This method will create IDummyService implementation with serviceName name.
+        IDummyService GetNamedDummyService(string serviceName, string namePart1, string namePart2);
+
+        // Generic methods are also allowed as factory methods.
+        TService CreateService<TService>();
+
+        // Something that is common for event-sourcing implementations.
+        IHandler<TMessage> CreateHandler<TMessage>();
+    }
+
+    // ENDSAMPLE
+}

--- a/src/Lamar.AutoFactory.Testing/Lamar.AutoFactory.Testing.csproj
+++ b/src/Lamar.AutoFactory.Testing/Lamar.AutoFactory.Testing.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <AssemblyName>Lamar.AutoFactory.Testing</AssemblyName>
+    <PackageId>Lamar.AutoFactory.Testing</PackageId>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Lamar.AutoFactory\Lamar.AutoFactory.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="Shouldly" Version="2.8.3" />
+    <PackageReference Include="Moq" Version="4.8.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/Lamar.AutoFactory.Testing/Properties/AssemblyInfo.cs
+++ b/src/Lamar.AutoFactory.Testing/Properties/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("StructureMap.AutoFactory.Testing")]
+[assembly: AssemblyTrademark("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("fa9f954b-ee4a-4172-b38b-a342df9ec15f")]

--- a/src/Lamar.AutoFactory.Testing/ProxyFactoryTests.cs
+++ b/src/Lamar.AutoFactory.Testing/ProxyFactoryTests.cs
@@ -1,0 +1,59 @@
+using System;
+using Castle.DynamicProxy;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace Lamar.AutoFactory.Testing
+{
+    public class ProxyFactoryTests
+    {
+        public interface IFactory
+        {
+            IService CreateService();
+        }
+
+        public interface IService
+        {
+        }
+
+        public class Service : IService
+        {
+        }
+
+        [Fact]
+        public void Should_create_a_proxy_factory()
+        {
+            var proxyGenerator = new ProxyGenerator();
+            var context = new Mock<IServiceContext>().Object;
+
+            var proxyFactory = new ProxyFactory<IFactory>(proxyGenerator, context, new DefaultAutoFactoryConventionProvider());
+
+            var factory = proxyFactory.Create();
+
+            factory.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void Should_build_the_service_by_return_type_from_context()
+        {
+            var proxyGenerator = new ProxyGenerator();
+            var contextMock = new Mock<IServiceContext>();
+            var containerMock = new Mock<IContainer>();
+
+            var service = new Service();
+
+            contextMock.Setup(x => x.GetInstance<IContainer>()).Returns(containerMock.Object);
+            containerMock.Setup(x => x.TryGetInstance(typeof(IService))).Returns(service);
+
+            var proxyFactory = new ProxyFactory<IFactory>(proxyGenerator, contextMock.Object, new DefaultAutoFactoryConventionProvider());
+
+            var factory = proxyFactory.Create();
+
+            var built = factory.CreateService();
+
+            built.ShouldNotBeNull();
+            built.ShouldBe(service);
+        }
+    }
+}

--- a/src/Lamar.AutoFactory.Testing/Samples.cs
+++ b/src/Lamar.AutoFactory.Testing/Samples.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Shouldly;
+using Xunit;
+
+namespace Lamar.AutoFactory.Testing
+{
+    public class Samples
+    {
+        // SAMPLE: simple-factory
+        [Fact]
+        public void Simple_factory_creation()
+        {
+            var container = new Container(cfg =>
+            {
+                cfg.For<IDummyService>().Use<DummyService>();
+                cfg.For<ISimpleDummyFactory>().CreateFactory();
+            });
+
+            var factory = container.GetInstance<ISimpleDummyFactory>();
+
+            var component = factory.CreateDummyService();
+
+            component.ShouldNotBeNull();
+            component.ShouldBeOfType<DummyService>();
+        }
+
+        // ENDSAMPLE
+    }
+
+    // SAMPLE: ISimpleDummyFactory
+    public interface ISimpleDummyFactory
+    {
+        IDummyService CreateDummyService();
+    }
+
+    // ENDSAMPLE
+}

--- a/src/Lamar.AutoFactory/AutoFactoryExtensions.cs
+++ b/src/Lamar.AutoFactory/AutoFactoryExtensions.cs
@@ -1,5 +1,7 @@
-using System;
 using Castle.DynamicProxy;
+using System;
+using Lamar.IoC.Instances;
+using LamarCodeGeneration.Model;
 using LamarCodeGeneration.Util;
 
 namespace Lamar.AutoFactory
@@ -61,6 +63,12 @@ namespace Lamar.AutoFactory
 
                 return proxyFactory.Create();
             };
+        }
+
+        public static bool HasExplicitName(this Instance instance)
+        {
+            // NOTE: I suspect this is a bit too naive
+            return !instance.Name.Equals("default") && !instance.Name.Equals(Variable.DefaultArgName(instance.ImplementationType));
         }
     }
 }

--- a/src/Lamar.AutoFactory/AutoFactoryExtensions.cs
+++ b/src/Lamar.AutoFactory/AutoFactoryExtensions.cs
@@ -1,0 +1,66 @@
+using System;
+using Castle.DynamicProxy;
+using LamarCodeGeneration.Util;
+
+namespace Lamar.AutoFactory
+{
+    public static class AutoFactoryExtensions
+    {
+        private static readonly ProxyGenerator proxyGenerator = new ProxyGenerator();
+
+        public static void CreateFactory<TPluginType>(this ServiceRegistry.InstanceExpression<TPluginType> expression)
+            where TPluginType : class
+        {
+            CreateFactory(expression, new DefaultAutoFactoryConventionProvider());
+        }
+
+        public static void CreateFactory<TPluginType>(this ServiceRegistry.InstanceExpression<TPluginType> expression,
+            IAutoFactoryConventionProvider conventionProvider)
+            where TPluginType : class
+        {
+            var callback = CreateFactoryCallback<TPluginType>(conventionProvider);
+
+            expression.Use(callback);
+        }
+
+        public static void CreateFactory<TPluginType, TConventionProvider>(
+            this ServiceRegistry.InstanceExpression<TPluginType> expression)
+            where TPluginType : class
+            where TConventionProvider : IAutoFactoryConventionProvider
+        {
+            var callback = CreateFactoryCallback<TPluginType, TConventionProvider>();
+
+            expression.Use(callback);
+        }
+
+        private static string GetDescription<TPluginType>() where TPluginType : class
+        {
+            return "AutoFactory builder for " + typeof(TPluginType).GetFullName();
+        }
+
+        private static Func<IServiceContext, TPluginType> CreateFactoryCallback<TPluginType>(IAutoFactoryConventionProvider conventionProvider)
+            where TPluginType : class
+        {
+            return ctxt =>
+            {
+                var proxyFactory = new ProxyFactory<TPluginType>(proxyGenerator, ctxt, conventionProvider);
+
+                return proxyFactory.Create();
+            };
+        }
+
+        private static Func<IServiceContext, TPluginType> CreateFactoryCallback<TPluginType, TConventionProvider>()
+            where TPluginType : class
+            where TConventionProvider : IAutoFactoryConventionProvider
+        {
+            return ctxt =>
+            {
+                var conventionProvider = ctxt.GetInstance<TConventionProvider>();
+
+                var proxyFactory = new ProxyFactory<TPluginType>(proxyGenerator, ctxt, conventionProvider);
+
+                return proxyFactory.Create();
+            };
+        }
+    }
+}

--- a/src/Lamar.AutoFactory/AutoFactoryMethodDefinition.cs
+++ b/src/Lamar.AutoFactory/AutoFactoryMethodDefinition.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Lamar.AutoFactory
+{
+    public class AutoFactoryMethodDefinition : IAutoFactoryMethodDefinition
+    {
+        public AutoFactoryMethodDefinition(AutoFactoryMethodType methodType, Type instanceType, string instanceName)
+        {
+            MethodType = methodType;
+            InstanceType = instanceType;
+            InstanceName = instanceName;
+        }
+
+        public AutoFactoryMethodType MethodType { get; }
+
+        public Type InstanceType { get; }
+
+        public string InstanceName { get; }
+    }
+}

--- a/src/Lamar.AutoFactory/AutoFactoryMethodType.cs
+++ b/src/Lamar.AutoFactory/AutoFactoryMethodType.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Lamar.AutoFactory
+{
+    public enum AutoFactoryMethodType
+    {
+        /// <summary>
+        /// Method is used to create an instance i.e. factory method.
+        /// </summary>
+        GetInstance = 0,
+
+        /// <summary>
+        /// Special method to return the list of names of registered implementations.
+        /// </summary>
+        GetNames = 1
+    }
+}

--- a/src/Lamar.AutoFactory/DefaultAutoFactoryConventionProvider.cs
+++ b/src/Lamar.AutoFactory/DefaultAutoFactoryConventionProvider.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Lamar.AutoFactory
+{
+    public class DefaultAutoFactoryConventionProvider : IAutoFactoryConventionProvider
+    {
+        public IAutoFactoryMethodDefinition GetMethodDefinition(MethodInfo methodInfo, IList<object> arguments)
+        {
+            if (methodInfo.Name.StartsWith("GetNames", StringComparison.OrdinalIgnoreCase)
+                && methodInfo.IsGenericMethod
+                && methodInfo.GetGenericArguments().Any()
+                && methodInfo.ReturnType.IsAssignableFrom(typeof(List<string>)))
+            {
+                return new AutoFactoryMethodDefinition(AutoFactoryMethodType.GetNames, methodInfo.GetGenericArguments().First(), null);
+            }
+
+            var pluginType = methodInfo.ReturnType;
+
+            // do nothing with void methods for now
+            if (pluginType == typeof(void))
+            {
+                return null;
+            }
+
+            var name = tryGetInstanceName(methodInfo, arguments);
+
+            var isNamed = !string.IsNullOrEmpty(name);
+
+            return new AutoFactoryMethodDefinition(AutoFactoryMethodType.GetInstance, pluginType, name);
+        }
+
+        private static string tryGetInstanceName(MethodInfo methodInfo, IList<object> arguments)
+        {
+            return methodInfo.Name.StartsWith("GetNamed", StringComparison.OrdinalIgnoreCase)
+                   && arguments.Any()
+                ? Convert.ToString(arguments.First())
+                : null;
+        }
+    }
+}

--- a/src/Lamar.AutoFactory/FactoryInterceptor.cs
+++ b/src/Lamar.AutoFactory/FactoryInterceptor.cs
@@ -1,5 +1,6 @@
-using System;
+using System.Linq;
 using Castle.DynamicProxy;
+using Lamar;
 
 namespace Lamar.AutoFactory
 {
@@ -31,13 +32,13 @@ namespace Lamar.AutoFactory
                         : _container.TryGetInstance(methodDefinition.InstanceType);
                     break;
 
-                // TODO: When named instances are supported?
-                //case AutoFactoryMethodType.GetNames:
-                //    invocation.ReturnValue = _container.Model.AllInstances
-                //        .Where(x => x.PluginType == methodDefinition.InstanceType)
-                //        .Select(x => x.Instance.HasExplicitName() ? x.Name : string.Empty)
-                //        .ToList();
-                //    break;
+                
+                case AutoFactoryMethodType.GetNames:
+                    invocation.ReturnValue = _container.Model.AllInstances
+                        .Where(x => x.ServiceType == methodDefinition.InstanceType)
+                        .Select(x => x.Instance.HasExplicitName() ? x.Name : string.Empty)
+                        .ToList();
+                    break;
             }
         }
     }

--- a/src/Lamar.AutoFactory/FactoryInterceptor.cs
+++ b/src/Lamar.AutoFactory/FactoryInterceptor.cs
@@ -1,0 +1,44 @@
+using System;
+using Castle.DynamicProxy;
+
+namespace Lamar.AutoFactory
+{
+    public class FactoryInterceptor : IInterceptor
+    {
+        private readonly IContainer _container;
+        private readonly IAutoFactoryConventionProvider _conventionProvider;
+
+        public FactoryInterceptor(IContainer container, IAutoFactoryConventionProvider conventionProvider)
+        {
+            _container = container;
+            _conventionProvider = conventionProvider;
+        }
+
+        public void Intercept(IInvocation invocation)
+        {
+            var methodDefinition = _conventionProvider.GetMethodDefinition(invocation.Method, invocation.Arguments);
+
+            if (methodDefinition == null)
+            {
+                return;
+            }
+
+            switch (methodDefinition.MethodType)
+            {
+                case AutoFactoryMethodType.GetInstance:
+                    invocation.ReturnValue = !string.IsNullOrEmpty(methodDefinition.InstanceName)
+                        ? _container.TryGetInstance(methodDefinition.InstanceType, methodDefinition.InstanceName)
+                        : _container.TryGetInstance(methodDefinition.InstanceType);
+                    break;
+
+                // TODO: When named instances are supported?
+                //case AutoFactoryMethodType.GetNames:
+                //    invocation.ReturnValue = _container.Model.AllInstances
+                //        .Where(x => x.PluginType == methodDefinition.InstanceType)
+                //        .Select(x => x.Instance.HasExplicitName() ? x.Name : string.Empty)
+                //        .ToList();
+                //    break;
+            }
+        }
+    }
+}

--- a/src/Lamar.AutoFactory/IAutoFactoryConventionProvider.cs
+++ b/src/Lamar.AutoFactory/IAutoFactoryConventionProvider.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Lamar.AutoFactory
+{
+    public interface IAutoFactoryConventionProvider
+    {
+        // SAMPLE: GetMethodDefinition
+        IAutoFactoryMethodDefinition GetMethodDefinition(MethodInfo methodInfo, IList<object> arguments);
+
+        //ENDSAMPLE
+    }
+}

--- a/src/Lamar.AutoFactory/IAutoFactoryMethodDefinition.cs
+++ b/src/Lamar.AutoFactory/IAutoFactoryMethodDefinition.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace Lamar.AutoFactory
+{
+    // SAMPLE: IAutoFactoryMethodDefinition
+    /// <summary>
+    /// Describes how AutoFactory should treat the specific method declared in an abstract factory interface.
+    /// </summary>
+    public interface IAutoFactoryMethodDefinition
+    {
+        /// <summary>
+        /// The method type. See <see cref="AutoFactoryMethodType"/> for possible values.
+        /// </summary>
+        AutoFactoryMethodType MethodType { get; }
+
+        /// <summary>
+        /// The instance type to create.
+        /// </summary>
+        Type InstanceType { get; }
+
+        /// <summary>
+        /// The instance name if available.
+        /// </summary>
+        string InstanceName { get; }
+    }
+
+    // ENDSAMPLE
+}

--- a/src/Lamar.AutoFactory/Lamar.AutoFactory.csproj
+++ b/src/Lamar.AutoFactory/Lamar.AutoFactory.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>Lamar.AutoFactory</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
     <VersionPrefix>1.0.1</VersionPrefix>
-    <Authors>Dmytro Dziuma, Jeremy D. Miller</Authors>
+    <Authors>Jeremy D. Miller</Authors>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Lamar.AutoFactory</AssemblyName>

--- a/src/Lamar.AutoFactory/Lamar.AutoFactory.csproj
+++ b/src/Lamar.AutoFactory/Lamar.AutoFactory.csproj
@@ -1,0 +1,41 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>AutoFactory Support for Lamar</Description>
+    <AssemblyTitle>Lamar.AutoFactory</AssemblyTitle>
+    <NeutralLanguage>en-US</NeutralLanguage>
+    <VersionPrefix>1.0.1</VersionPrefix>
+    <Authors>Dmytro Dziuma, Jeremy D. Miller</Authors>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AssemblyName>Lamar.AutoFactory</AssemblyName>
+    <PackageId>Lamar.AutoFactory</PackageId>
+    <PackageTags>IoC</PackageTags>
+    <PackageProjectUrl>http://jasperfx.github.io/lamar</PackageProjectUrl>
+    <PackageLicenseUrl>https://raw.githubusercontent.com/JasperFx/lamar/master/README.md</PackageLicenseUrl>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>git://github.com/jasperfx/lamar</RepositoryUrl>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Castle.Core" Version="4.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Lamar\Lamar.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Lamar.AutoFactory/Properties/AssemblyInfo.cs
+++ b/src/Lamar.AutoFactory/Properties/AssemblyInfo.cs
@@ -1,0 +1,18 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("StructureMap.AutoFactory")]
+[assembly: AssemblyTrademark("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("cb4b9035-721d-4fec-abc7-51fb4e795ce6")]

--- a/src/Lamar.AutoFactory/ProxyFactory.cs
+++ b/src/Lamar.AutoFactory/ProxyFactory.cs
@@ -1,5 +1,6 @@
-using System;
 using Castle.DynamicProxy;
+using Lamar;
+using Lamar.AutoFactory;
 
 namespace Lamar.AutoFactory
 {

--- a/src/Lamar.AutoFactory/ProxyFactory.cs
+++ b/src/Lamar.AutoFactory/ProxyFactory.cs
@@ -1,0 +1,28 @@
+using System;
+using Castle.DynamicProxy;
+
+namespace Lamar.AutoFactory
+{
+    public class ProxyFactory<TPluginType> where TPluginType : class
+    {
+        private readonly ProxyGenerator _proxyGenerator;
+        private readonly IServiceContext _context;
+        private readonly IAutoFactoryConventionProvider _conventionProvider;
+
+        public ProxyFactory(ProxyGenerator proxyGenerator, IServiceContext context, IAutoFactoryConventionProvider conventionProvider)
+        {
+            _proxyGenerator = proxyGenerator;
+            _context = context;
+            _conventionProvider = conventionProvider;
+        }
+
+        public TPluginType Create()
+        {
+            var container = _context.GetInstance<IContainer>();
+
+            var interceptor = new FactoryInterceptor(container, _conventionProvider);
+
+            return _proxyGenerator.CreateInterfaceProxyWithoutTarget<TPluginType>(interceptor);
+        }
+    }
+}


### PR DESCRIPTION
This was a fairly naive import of StructureMap.AutoFactory and it's unit tests to address #4 .  There was very little code modification from structure map, mostly just adjusting to the minor class name differences.  I also removed support for using explicit arguments as that's not supported in Lamar.