### PR TITLE
Cast when service factory is unknown

### DIFF
--- a/src/Lamar.Testing/Bugs/Bug_167_implementation_factory.cs
+++ b/src/Lamar.Testing/Bugs/Bug_167_implementation_factory.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using StructureMap.Testing.Widget;
+using Xunit;
+
+namespace Lamar.Testing.Bugs
+{
+    public class Test
+    {
+        [Fact]
+        public void Should_resolve_ctor_injection()
+        {
+            var container = new Container(x =>
+            {
+                var serviceDescriptor = ServiceDescriptor.Transient(typeof(IWidget), provider => provider.GetRequiredService(typeof(AWidget)));
+                x.Add(serviceDescriptor);
+            });
+
+            var result = container.GetInstance<MyClass>();
+
+            result.ShouldBeOfType<MyClass>();
+        }
+
+        private class MyClass
+        {
+            public MyClass(IWidget widget)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolves #167.

When building the expression to inject a service into a constructor, `InlineLambdaCreationFrame.WriteExpressions` assumes the service factory return type is directly compatible with the argument being resolved. This is not the case when not using the generic overloads to create the service descriptor. This pr teaches `InlineLambdaCreationFrame` to assume that type `object` is compatible with the resolving service type.