### PR TITLE
Inverse registration syntax

### DIFF
--- a/documentation/documentation/ioc/registration/registry-dsl.md
+++ b/documentation/documentation/ioc/registration/registry-dsl.md
@@ -75,6 +75,24 @@ You can also register named instances with the following shorthand:
 
 <[sample:named-instances-shorthand]>
 
+## Inverse Registrations with Use().For()
+
+In some scenarios, a type may implement multiple interfaces.
+You could register this with a separate `For().Use()` line for each interface, but if
+the type is to be a singleton, then registering it this way will give you a 
+*different* singleton instance for each interface. To use the same instance across multiple
+interfaces, you can use the reverse syntax.
+
+<[sample:inverse-registration]>
+
+The same thing works for scoped registrations; using `.Scoped()` in place of `.Singleton()` in
+the above sample would result in the same instance being returned when resolving any one of the 
+registered interfaces for the duration of the scope.
+
+A transient registration can also be made using `.Transient()`, in which case the behaviour is exactly
+the same as with the more usual `For().Use()` syntax; it's just a convenient shorthand in the
+case of a type that implements many interfaces.
+
 [1]: http://martinfowler.com/bliki/FluentInterface.html
 [2]: http://en.wikipedia.org/wiki/Closure_%28computer_programming%29
 

--- a/src/Lamar.Testing/IoC/one_instance_across_multiple_interfaces.cs
+++ b/src/Lamar.Testing/IoC/one_instance_across_multiple_interfaces.cs
@@ -1,0 +1,128 @@
+﻿using Xunit;
+
+namespace Lamar.Testing.IoC
+{
+    public class one_instance_across_multiple_interfaces
+    {
+        [Fact]
+        public void when_singleton_both_interfaces_give_same_instance()
+        {
+            var container = new Container(services =>
+            {
+                services.Use<Implementation>()
+                    .Singleton()
+                    .For<IServiceA>()
+                    .For<IServiceB>();
+            });
+
+            var instanceA = container.GetInstance<IServiceA>();
+            var instanceB = container.GetInstance<IServiceB>();
+
+            Assert.Same(instanceA, instanceB);
+        }
+
+        [Fact]
+        public void when_transient_both_interfaces_give_new_instance()
+        {
+            var container = new Container(services =>
+            {
+                services.Use<Implementation>()
+                    .Transient()
+                    .For<IServiceA>()
+                    .For<IServiceB>();
+            });
+
+            var instanceA = container.GetInstance<IServiceA>();
+            var instanceB = container.GetInstance<IServiceB>();
+
+            Assert.NotSame(instanceA, instanceB);
+        }
+
+        [Fact]
+        public void when_scoped_instance_is_consistent_with_scope()
+        {
+            var container = new Container(services =>
+            {
+                services.Use<Implementation>()
+                    .Scoped()
+                    .For<IServiceA>()
+                    .For<IServiceB>();
+            });
+
+            var instanceA = container.GetInstance<IServiceA>();
+            var instanceB = container.GetInstance<IServiceB>();
+
+            var scope1 = container.GetNestedContainer();
+
+            var instanceA1 = scope1.GetInstance<IServiceA>();
+            var instanceB1 = scope1.GetInstance<IServiceB>();
+
+            var scope2 = container.GetNestedContainer();
+
+            var instanceA2 = scope2.GetInstance<IServiceA>();
+            var instanceB2 = scope2.GetInstance<IServiceB>();
+
+            Assert.Same(instanceA, instanceB);
+            Assert.Same(instanceA1, instanceB1);
+            Assert.Same(instanceA2, instanceB2);
+
+            Assert.NotSame(instanceA, instanceA1);
+            Assert.NotSame(instanceA, instanceA2);
+            Assert.NotSame(instanceA1, instanceA2);
+
+            Assert.NotSame(instanceB, instanceB1);
+            Assert.NotSame(instanceB, instanceB2);
+            Assert.NotSame(instanceB1, instanceB2);
+        }
+
+        [Fact]
+        public void when_named_instance_is_consistent_with_name()
+        {
+            var container = new Container(services =>
+            {
+                services.Use<Implementation>()
+                    .Named("Group1")
+                    .For<IServiceA>()
+                    .For<IServiceB>();
+
+                services.Use<Implementation>()
+                    .Named("Group2")
+                    .For<IServiceA>()
+                    .For<IServiceB>();
+            });
+
+            var instanceA1 = container.GetInstance<IServiceA>("Group1");
+            var instanceB1 = container.GetInstance<IServiceB>("Group1");
+
+            var instanceA2 = container.GetInstance<IServiceA>("Group2");
+            var instanceB2 = container.GetInstance<IServiceB>("Group2");
+
+            Assert.Same(instanceA1, instanceB1);
+            Assert.Same(instanceA2, instanceB2);
+
+            Assert.NotSame(instanceA1, instanceA2);
+            Assert.NotSame(instanceB1, instanceB2);
+        }
+
+        private interface IServiceA
+        {
+            void MethodA();
+        }
+
+        private interface IServiceB
+        {
+            void MethodB();
+        }
+
+        private class Implementation : IServiceA, IServiceB
+        {
+            public void MethodA()
+            {
+            }
+
+            public void MethodB()
+            {
+            }
+        }
+    }
+}

--- a/src/Lamar.Testing/IoC/one_instance_across_multiple_interfaces.cs
+++ b/src/Lamar.Testing/IoC/one_instance_across_multiple_interfaces.cs
@@ -19,7 +19,7 @@ namespace Lamar.Testing.IoC
             var instanceA = container.GetInstance<IServiceA>();
             var instanceB = container.GetInstance<IServiceB>();
 
-            Assert.Same(instanceA, instanceB);
+            instanceA.ShouldBeTheSameAs(instanceB);
         }
 
         //ENDSAMPLE
@@ -38,7 +38,7 @@ namespace Lamar.Testing.IoC
             var instanceA = container.GetInstance<IServiceA>();
             var instanceB = container.GetInstance<IServiceB>();
 
-            Assert.NotSame(instanceA, instanceB);
+            instanceA.ShouldNotBeTheSameAs(instanceB);
         }
 
         [Fact]
@@ -65,17 +65,17 @@ namespace Lamar.Testing.IoC
             var instanceA2 = scope2.GetInstance<IServiceA>();
             var instanceB2 = scope2.GetInstance<IServiceB>();
 
-            Assert.Same(instanceA, instanceB);
-            Assert.Same(instanceA1, instanceB1);
-            Assert.Same(instanceA2, instanceB2);
+            instanceA.ShouldBeTheSameAs(instanceB);
+            instanceA1.ShouldBeTheSameAs(instanceB1);
+            instanceA2.ShouldBeTheSameAs(instanceB2);
 
-            Assert.NotSame(instanceA, instanceA1);
-            Assert.NotSame(instanceA, instanceA2);
-            Assert.NotSame(instanceA1, instanceA2);
+            instanceA.ShouldNotBeTheSameAs(instanceA1);
+            instanceA.ShouldNotBeTheSameAs(instanceA2);
+            instanceA1.ShouldNotBeTheSameAs(instanceA2);
 
-            Assert.NotSame(instanceB, instanceB1);
-            Assert.NotSame(instanceB, instanceB2);
-            Assert.NotSame(instanceB1, instanceB2);
+            instanceB.ShouldNotBeTheSameAs(instanceB1);
+            instanceB.ShouldNotBeTheSameAs(instanceB2);
+            instanceB1.ShouldNotBeTheSameAs(instanceB2);
         }
 
         [Fact]
@@ -100,11 +100,11 @@ namespace Lamar.Testing.IoC
             var instanceA2 = container.GetInstance<IServiceA>("Group2");
             var instanceB2 = container.GetInstance<IServiceB>("Group2");
 
-            Assert.Same(instanceA1, instanceB1);
-            Assert.Same(instanceA2, instanceB2);
+            instanceA1.ShouldBeTheSameAs(instanceB1);
+            instanceA2.ShouldBeTheSameAs(instanceB2);
 
-            Assert.NotSame(instanceA1, instanceA2);
-            Assert.NotSame(instanceB1, instanceB2);
+            instanceA1.ShouldNotBeTheSameAs(instanceA2);
+            instanceB1.ShouldNotBeTheSameAs(instanceB2);
         }
 
         private interface IServiceA

--- a/src/Lamar.Testing/IoC/one_instance_across_multiple_interfaces.cs
+++ b/src/Lamar.Testing/IoC/one_instance_across_multiple_interfaces.cs
@@ -4,6 +4,7 @@ namespace Lamar.Testing.IoC
 {
     public class one_instance_across_multiple_interfaces
     {
+        //SAMPLE: inverse-registration
         [Fact]
         public void when_singleton_both_interfaces_give_same_instance()
         {
@@ -20,6 +21,8 @@ namespace Lamar.Testing.IoC
 
             Assert.Same(instanceA, instanceB);
         }
+
+        //ENDSAMPLE
 
         [Fact]
         public void when_transient_both_interfaces_give_new_instance()

--- a/src/Lamar.Testing/SpecificationExtensions.cs
+++ b/src/Lamar.Testing/SpecificationExtensions.cs
@@ -65,6 +65,12 @@ namespace Lamar.Testing
             return (T)actual;
         }
 
+        public static object ShouldBeTheSameAs(this object actual, object expected)
+        {
+            ReferenceEquals(actual, expected).ShouldBeTrue();
+            return expected;
+        }
+
         public static object ShouldNotBeTheSameAs(this object actual, object expected)
         {
             ReferenceEquals(actual, expected).ShouldBeFalse();

--- a/src/Lamar/InverseInstanceExpression.cs
+++ b/src/Lamar/InverseInstanceExpression.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using Lamar.IoC.Instances;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Lamar
+{
+    public partial class ServiceRegistry
+    {
+        public class InverseInstanceExpression<TImpl> where TImpl : class
+        {
+            public InverseInstanceExpression(ServiceRegistry parent)
+            {
+                _parent = parent;
+            }
+
+            private readonly ServiceRegistry _parent;
+
+            public ScopedInverseInstanceExpression<TImpl> Named(string name)
+            {
+                return new ScopedInverseInstanceExpression<TImpl>(_parent, name);
+            }
+
+            public ScopedInverseInstanceExpression<TImpl> Scoped()
+            {
+                return new ScopedInverseInstanceExpression<TImpl>(_parent, ServiceLifetime.Scoped);
+            }
+
+            public ScopedInverseInstanceExpression<TImpl> Singleton()
+            {
+                return new ScopedInverseInstanceExpression<TImpl>(_parent, ServiceLifetime.Singleton);
+            }
+
+            public ScopedInverseInstanceExpression<TImpl> Transient()
+            {
+                return new ScopedInverseInstanceExpression<TImpl>(_parent, ServiceLifetime.Transient);
+            }
+        }
+
+        public class ScopedInverseInstanceExpression<TImpl> where TImpl : class
+        {
+            public ScopedInverseInstanceExpression(ServiceRegistry parent, string name)
+            {
+                _parent = parent;
+                _name = name;
+            }
+
+            public ScopedInverseInstanceExpression(ServiceRegistry parent, ServiceLifetime lifetime)
+            {
+                _parent = parent;
+                _lifetime = lifetime;
+            }
+
+            private ServiceRegistry _parent;
+
+            private string _name;
+            private ServiceLifetime _lifetime;
+            private ConstructorInstance<TImpl> _rootInstance;
+
+            public ScopedInverseInstanceExpression<TImpl> For<TService>()
+                where TService : class
+            {
+                if (!typeof(TService).IsAssignableFrom(typeof(TImpl)))
+                {
+                    throw new ArgumentException($"There is no conversion from {typeof(TImpl).Name} to {typeof(TImpl).Name}");
+                }
+
+                AddRootRegistration();
+
+                var instanceExpression = _parent.For<TService>();
+                Instance instance;
+
+                if (String.IsNullOrEmpty(_name))
+                {
+                    instance = instanceExpression.Use(c => (TService)c.GetInstance(typeof(TImpl)));
+                }
+                else
+                {
+                    instance = instanceExpression.Use(c => (TService)c.GetInstance(typeof(TImpl), _name));
+                }
+
+                instance.Lifetime = _lifetime;
+
+                return this;
+            }
+
+            private void AddRootRegistration()
+            {
+                if (_rootInstance is null)
+                {
+                    _rootInstance = _parent.For<TImpl>().Use<TImpl>();
+
+                    _rootInstance.Lifetime = _lifetime;
+                    if (!String.IsNullOrEmpty(_name))
+                    {
+                        _rootInstance.Named(_name);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Lamar/InverseInstanceExpression.cs
+++ b/src/Lamar/InverseInstanceExpression.cs
@@ -75,7 +75,7 @@ namespace Lamar
                 }
                 else
                 {
-                    instance = instanceExpression.Use(c => (TService)c.GetInstance(typeof(TImpl), _name));
+                    instance = instanceExpression.Use(c => (TService)c.GetInstance(typeof(TImpl), _name)).Named(_name);
                 }
 
                 instance.Lifetime = _lifetime;

--- a/src/Lamar/ServiceRegistry.cs
+++ b/src/Lamar/ServiceRegistry.cs
@@ -35,7 +35,7 @@ namespace Lamar
         }
     }
 
-    public class ServiceRegistry : List<ServiceDescriptor>, IServiceCollection
+    public partial class ServiceRegistry : List<ServiceDescriptor>, IServiceCollection
     {
         public static ServiceRegistry For(Action<ServiceRegistry> configuration)
         {
@@ -406,8 +406,11 @@ namespace Lamar
 
             return policies;
         }
-        
 
+        public InverseInstanceExpression<T> Use<T>() where T : class
+        {
+            return new InverseInstanceExpression<T>(this);
+        }
     }
 
     public enum DynamicAssemblySharing


### PR DESCRIPTION
Simple inverse syntax to be able to share one instance across multiple interface registrations.