### PR TITLE
Option to skip WhatDoIHave() when calling AssertConfigurationIsValid()

### DIFF
--- a/src/Lamar/Container.cs
+++ b/src/Lamar/Container.cs
@@ -57,7 +57,7 @@ namespace Lamar
         }
 
 
-        public void AssertConfigurationIsValid(AssertMode mode = AssertMode.Full)
+        public void AssertConfigurationIsValid(AssertMode mode = AssertMode.Full, bool showKnownRegistrationsOnError = true)
         {
             using (var writer = new StringWriter())
             {
@@ -65,13 +65,16 @@ namespace Lamar
 
                 if (!hasErrors && mode == AssertMode.Full) hasErrors = buildAndValidateAll(writer);
 
-                if (hasErrors)
+                if (hasErrors && showKnownRegistrationsOnError)
                 {
                     writer.WriteLine();
                     writer.WriteLine();
                     writer.WriteLine("The known registrations are:");
                     writer.WriteLine(WhatDoIHave());
+                }
 
+                if (hasErrors)
+                {
                     throw new ContainerValidationException(writer.ToString());
                 }
             }


### PR DESCRIPTION
Proposed solution to https://github.com/JasperFx/lamar/issues/180

I think the above is the simplest solution to the problem. However, perhaps a nicer alternative would be to remove the `WhatDoIHave()` output from the `ContainerValidationException` exception `message` entirely and instead store it in a new property on `ContainerValidationException`? That way the console and logging framework writes would be reduced in size and contain just the error information, but the full `WhatDoIHave()` detail would be available in the exception where required.