### PR TITLE
MVC Endpoints not seen when controllers are registered from a ServiceRegistry

### DIFF
--- a/src/LamarWithAspNetCore3/HelloWorldController.cs
+++ b/src/LamarWithAspNetCore3/HelloWorldController.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace LamarWithAspNetCore3
+{
+	[ApiController]
+	[Route("[controller]")]
+	public class MyController : ControllerBase
+	{
+		[HttpGet("helloworld")]
+		public string GetHelloWorld()
+		{
+			return "Hello World!";
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a (currently failling) test demonstrating that MVC endpoints are not seen when the [`MvcServiceCollectionExtensions.AddControllers`](https://github.com/aspnet/AspNetCore/blob/master/src/Mvc/Mvc/src/MvcServiceCollectionExtensions.cs#L87) method is called from a `ServiceRegistry`.

In this test, two other working cases are commented out for demonstration and/or comparison purpose. I'm not really sure this is specifically related to Lamar itself though, it might as well be an issue with Asp.Net Core.