### PR TITLE
Add an optional lifetime to the standard conventions

### DIFF
--- a/src/Lamar/Scanning/Conventions/AssemblyScanner.cs
+++ b/src/Lamar/Scanning/Conventions/AssemblyScanner.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using BaselineTypeDiscovery;
 using LamarCodeGeneration.Util;
+using Microsoft.Extensions.DependencyInjection;
 
 #pragma warning disable 1591
 
@@ -65,12 +66,22 @@ namespace Lamar.Scanning.Conventions
 
         public FindAllTypesFilter AddAllTypesOf<TPluginType>()
         {
-            return AddAllTypesOf(typeof(TPluginType));
+            return AddAllTypesOf(typeof(TPluginType), ServiceLifetime.Transient);
+        }
+
+        public FindAllTypesFilter AddAllTypesOf<TPluginType>(ServiceLifetime lifetime)
+        {
+            return AddAllTypesOf(typeof(TPluginType), lifetime);
         }
 
         public FindAllTypesFilter AddAllTypesOf(Type pluginType)
         {
-            var filter = new FindAllTypesFilter(pluginType);
+            return AddAllTypesOf(pluginType, ServiceLifetime.Transient);
+        }
+
+        public FindAllTypesFilter AddAllTypesOf(Type pluginType, ServiceLifetime lifetime)
+        {
+            var filter = new FindAllTypesFilter(pluginType, lifetime);
             With(filter);
 
             return filter;
@@ -119,13 +130,23 @@ namespace Lamar.Scanning.Conventions
 
         public void WithDefaultConventions()
         {
-            var convention = new DefaultConventionScanner();
+            WithDefaultConventions(ServiceLifetime.Transient);
+        }
+
+        public void WithDefaultConventions(ServiceLifetime lifetime)
+        {
+            var convention = new DefaultConventionScanner(lifetime);
             With(convention);
         }
 
         public void WithDefaultConventions(OverwriteBehavior behavior)
         {
-            var convention = new DefaultConventionScanner
+            WithDefaultConventions(behavior, ServiceLifetime.Transient);
+        }
+
+        public void WithDefaultConventions(OverwriteBehavior behavior, ServiceLifetime lifetime)
+        {
+            var convention = new DefaultConventionScanner(lifetime)
             {
                 Overwrites = behavior
             };
@@ -135,20 +156,34 @@ namespace Lamar.Scanning.Conventions
 
         public void ConnectImplementationsToTypesClosing(Type openGenericType)
         {
-            var convention = new GenericConnectionScanner(openGenericType);
+            ConnectImplementationsToTypesClosing(openGenericType, ServiceLifetime.Transient);
+        }
+
+        public void ConnectImplementationsToTypesClosing(Type openGenericType, ServiceLifetime lifetime)
+        {
+            var convention = new GenericConnectionScanner(openGenericType, lifetime);
             With(convention);
         }
 
-
         public void RegisterConcreteTypesAgainstTheFirstInterface()
         {
-            var convention = new FirstInterfaceConvention();
+            RegisterConcreteTypesAgainstTheFirstInterface(ServiceLifetime.Transient);
+        }
+
+        public void RegisterConcreteTypesAgainstTheFirstInterface(ServiceLifetime lifetime)
+        {
+            var convention = new FirstInterfaceConvention(lifetime);
             With(convention);
         }
 
         public void SingleImplementationsOfInterface()
         {
-            var convention = new ImplementationMap();
+            SingleImplementationsOfInterface(ServiceLifetime.Transient);
+        }
+
+        public void SingleImplementationsOfInterface(ServiceLifetime lifetime)
+        {
+            var convention = new ImplementationMap(lifetime);
             With(convention);
         }
 

--- a/src/Lamar/Scanning/Conventions/DefaultConventionScanner.cs
+++ b/src/Lamar/Scanning/Conventions/DefaultConventionScanner.cs
@@ -8,6 +8,13 @@ namespace Lamar.Scanning.Conventions
 {
     public class DefaultConventionScanner : IRegistrationConvention
     {
+        private readonly ServiceLifetime _lifetime;
+
+        public DefaultConventionScanner(ServiceLifetime lifetime = ServiceLifetime.Transient)
+        {
+            _lifetime = lifetime;
+        }
+
         public OverwriteBehavior Overwrites { get; set; } = OverwriteBehavior.NewType;
 
         public void ScanTypes(TypeSet types, ServiceRegistry services)
@@ -17,7 +24,7 @@ namespace Lamar.Scanning.Conventions
             {
                 var serviceType = FindPluginType(type);
                 if (serviceType != null && ShouldAdd(services, serviceType, type))
-                    services.AddTransient(serviceType, type);
+                    services.Add(new ServiceDescriptor(serviceType, type, _lifetime));
             }
         }
 

--- a/src/Lamar/Scanning/Conventions/FirstInterfaceConvention.cs
+++ b/src/Lamar/Scanning/Conventions/FirstInterfaceConvention.cs
@@ -2,18 +2,26 @@ using System;
 using System.Linq;
 using BaselineTypeDiscovery;
 using LamarCodeGeneration.Util;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Lamar.Scanning.Conventions
 {
     public class FirstInterfaceConvention : IRegistrationConvention
     {
+        private readonly ServiceLifetime _lifetime;
+
+        public FirstInterfaceConvention(ServiceLifetime lifetime = ServiceLifetime.Transient)
+        {
+            _lifetime = lifetime;
+        }
+
         public void ScanTypes(TypeSet types, ServiceRegistry services)
         {
             foreach (var type in types.FindTypes(TypeClassification.Concretes).Where(x => x.GetConstructors().Any()))
             {
                 var interfaceType = type.GetInterfaces().FirstOrDefault(x => x != typeof(IDisposable));
                 if (interfaceType != null && !interfaceType.HasAttribute<LamarIgnoreAttribute>() &&
-                    !type.IsOpenGeneric()) services.AddType(interfaceType, type);
+                    !type.IsOpenGeneric()) services.AddType(interfaceType, type, _lifetime);
             }
         }
 

--- a/src/Lamar/Scanning/Conventions/IAssemblyScanner.cs
+++ b/src/Lamar/Scanning/Conventions/IAssemblyScanner.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Reflection;
 
@@ -42,9 +43,25 @@ namespace Lamar.Scanning.Conventions
 
         /// <summary>
         ///     Add all concrete types of the Plugin Type as Instances of Plugin Type
+        ///     with the specified lifetime
+        /// </summary>
+        /// <typeparam name="TPluginType"></typeparam>
+        /// <param name="lifetime"></param>
+        FindAllTypesFilter AddAllTypesOf<TPluginType>(ServiceLifetime lifetime);
+
+        /// <summary>
+        ///     Add all concrete types of the Plugin Type as Instances of Plugin Type
         /// </summary>
         /// <param name="pluginType"></param>
         FindAllTypesFilter AddAllTypesOf(Type pluginType);
+
+        /// <summary>
+        ///     Add all concrete types of the Plugin Type as Instances of Plugin Type
+        ///     with the specified lifetime
+        /// </summary>
+        /// <param name="pluginType"></param>
+        /// <param name="lifetime"></param>
+        FindAllTypesFilter AddAllTypesOf(Type pluginType, ServiceLifetime lifetime);
 
         /// <summary>
         ///     Exclude types that match the Predicate from being scanned
@@ -112,6 +129,14 @@ namespace Lamar.Scanning.Conventions
         void WithDefaultConventions();
 
         /// <summary>
+        ///     Adds the DefaultConventionScanner to the scanning operations with the specified lifetime.
+        ///     I.e., a concrete class named "Something" that implements "ISomething" will be automatically
+        ///     added to PluginType "ISomething"
+        /// </summary>
+        /// <param name="lifetime"></param>
+        void WithDefaultConventions(ServiceLifetime lifetime);
+
+        /// <summary>
         ///     Adds the DefaultConventionScanner to the scanning operations.  I.e., a concrete
         ///     class named "Something" that implements "ISomething" will be automatically
         ///     added to PluginType "ISomething"
@@ -120,10 +145,26 @@ namespace Lamar.Scanning.Conventions
         void WithDefaultConventions(OverwriteBehavior behavior);
 
         /// <summary>
+        ///     Adds the DefaultConventionScanner to the scanning operations with the specified lifetime.
+        ///     I.e., a concrete class named "Something" that implements "ISomething" will be automatically
+        ///     added to PluginType "ISomething"
+        /// </summary>
+        /// <param name="behavior">Define whether or not Lamar should overwrite any existing registrations. Default is IfNew</param>
+        /// <param name="lifetime">The <see cref="ServiceLifetime"/> to use</param>
+        void WithDefaultConventions(OverwriteBehavior behavior, ServiceLifetime lifetime);
+
+        /// <summary>
         ///     Automatically registers all concrete types without primitive arguments
         ///     against its first interface, if any
         /// </summary>
         void RegisterConcreteTypesAgainstTheFirstInterface();
+
+        /// <summary>
+        ///     Automatically registers all concrete types without primitive arguments
+        ///     against its first interface, if any, using the specified lifetime
+        /// </summary>
+        /// <param name="lifetime"></param>
+        void RegisterConcreteTypesAgainstTheFirstInterface(ServiceLifetime lifetime);
 
         /// <summary>
         ///     Directs the scanning to automatically register any type that is the single
@@ -131,6 +172,14 @@ namespace Lamar.Scanning.Conventions
         ///     The filters apply
         /// </summary>
         void SingleImplementationsOfInterface();
+
+        /// <summary>
+        ///     Directs the scanning to automatically register any type that is the single
+        ///     implementation of an interface against that interface, using the specified lifetime.
+        ///     The filters apply
+        /// </summary>
+        /// <param name="lifetime"></param>
+        void SingleImplementationsOfInterface(ServiceLifetime lifetime);
 
         void TheCallingAssembly();
         void AssembliesFromApplicationBaseDirectory();
@@ -145,6 +194,14 @@ namespace Lamar.Scanning.Conventions
         /// <param name="openGenericType"></param>
         void ConnectImplementationsToTypesClosing(Type openGenericType);
 
+        /// <summary>
+        ///     Scans for PluginType's and Concrete Types that close the given open generic type
+        /// </summary>
+        /// <example>
+        /// </example>
+        /// <param name="openGenericType"></param>
+        /// <param name="lifetime"></param>
+        void ConnectImplementationsToTypesClosing(Type openGenericType, ServiceLifetime lifetime);
 
         /// <summary>
         ///     Choosing option will direct StructureMap to *also* scan files ending in '*.exe'

--- a/src/Lamar/Scanning/Conventions/ImplementationMap.cs
+++ b/src/Lamar/Scanning/Conventions/ImplementationMap.cs
@@ -2,11 +2,19 @@
 using System.Linq;
 using BaselineTypeDiscovery;
 using LamarCodeGeneration.Util;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Lamar.Scanning.Conventions
 {
     public class ImplementationMap : IRegistrationConvention
     {
+        private readonly ServiceLifetime _lifetime;
+
+        public ImplementationMap(ServiceLifetime lifetime = ServiceLifetime.Transient)
+        {
+            _lifetime = lifetime;
+        }
+
         public void ScanTypes(TypeSet types, ServiceRegistry services)
         {
             var interfaces = types.FindTypes(TypeClassification.Interfaces | TypeClassification.Closed)
@@ -17,7 +25,7 @@ namespace Lamar.Scanning.Conventions
             interfaces.Each(@interface =>
             {
                 var implementors = concretes.Where(x => x.CanBeCastTo(@interface)).ToArray();
-                if (implementors.Count() == 1) services.AddType(@interface, implementors.Single());
+                if (implementors.Count() == 1) services.Add(new ServiceDescriptor(@interface, implementors.Single(), _lifetime));
             });
         }
 

--- a/src/Lamar/Scanning/Conventions/ServiceCollectionExtensions.cs
+++ b/src/Lamar/Scanning/Conventions/ServiceCollectionExtensions.cs
@@ -55,12 +55,12 @@ namespace Lamar.Scanning.Conventions
             return false;
         }
 
-        public static Instance AddType(this IServiceCollection services, Type serviceType, Type implementationType)
+        public static Instance AddType(this IServiceCollection services, Type serviceType, Type implementationType, ServiceLifetime lifetime = ServiceLifetime.Transient)
         {
             var hasAlready = services.Any(x => x.Matches(serviceType, implementationType));
             if (!hasAlready)
             {
-                var instance = new ConstructorInstance(serviceType, implementationType, ServiceLifetime.Transient);
+                var instance = new ConstructorInstance(serviceType, implementationType, lifetime);
 
                 services.Add(instance);
 


### PR DESCRIPTION
Fixes #200, implementing an optional lifetime argument for the
standard conventions, and extendind the `IAssemblyScanner` API to
specify a lifetime.