### PR TITLE
Fix for Registration docs error, inheriting from Registry

### DIFF
--- a/src/Lamar.Testing/Samples/Models.cs
+++ b/src/Lamar.Testing/Samples/Models.cs
@@ -1,0 +1,28 @@
+﻿namespace Lamar.Testing.Samples
+{
+// SAMPLE: foobar-model
+    public interface IBar
+    {
+    }
+
+    public class Bar : IBar
+    {
+    }
+
+    public interface IFoo
+    {
+    }
+
+    public class Foo : IFoo
+    {
+        public IBar Bar { get; private set; }
+
+        public Foo(IBar bar)
+        {
+            Bar = bar;
+        }
+    }
+
+// ENDSAMPLE
+
+}

--- a/src/Lamar.Testing/Samples/Registries.cs
+++ b/src/Lamar.Testing/Samples/Registries.cs
@@ -1,0 +1,14 @@
+﻿namespace Lamar.Testing.Samples
+{
+// SAMPLE: foobar-registry
+    public class FooBarRegistry : ServiceRegistry
+    {
+        public FooBarRegistry()
+        {
+            For<IFoo>().Use<Foo>();
+            For<IBar>().Use<Bar>();
+        }
+    }
+
+// ENDSAMPLE
+}

--- a/src/StructureMap.Testing/Samples/model.cs
+++ b/src/StructureMap.Testing/Samples/model.cs
@@ -13,7 +13,7 @@ namespace StructureMap.Docs.samples
     }
 
 
-// SAMPLE: foobar-model
+// SAMPLE: foobar-model-structuremap
     public interface IBar
     {
     }

--- a/src/StructureMap.Testing/Samples/registries.cs
+++ b/src/StructureMap.Testing/Samples/registries.cs
@@ -2,7 +2,7 @@
 
 namespace StructureMap.Docs.samples
 {
-// SAMPLE: foobar-registry
+// SAMPLE: foobar-registry-structuremap
     public class FooBarRegistry : Registry
     {
         public FooBarRegistry()


### PR DESCRIPTION
Referring to this page: https://jasperfx.github.io/lamar/documentation/ioc/registration/

The sample "FooBarRegistry" is shown as subclassing Registry and
not ServiceRegistry. This was due to the doc tools picking up the
sample from the old StructureMap testing code.


I've picked up and copied the relevant code into the
Lamar.Testing.Samples namespace and renamted the original
code samples in the StructureMap test code.