### PR TITLE
Adds unit tests showing issues with DbContext scoping for ASP.NET Core 3

### DIFF
--- a/Lamar.sln
+++ b/Lamar.sln
@@ -51,15 +51,17 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Widget.Registration", "Widg
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LamarCodeGeneration", "src\LamarCodeGeneration\LamarCodeGeneration.csproj", "{2030BA2A-5D44-4BDA-9EF7-7EB0BC7A1C6F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lamar.Diagnostics", "src\Lamar.Diagnostics\Lamar.Diagnostics.csproj", "{5861C3EC-44F0-4FB3-8B69-3B349E4FDE22}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lamar.Diagnostics", "src\Lamar.Diagnostics\Lamar.Diagnostics.csproj", "{5861C3EC-44F0-4FB3-8B69-3B349E4FDE22}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LamarWithAspNetCore3", "src\LamarWithAspNetCore3\LamarWithAspNetCore3.csproj", "{A513986C-E435-495D-B056-8C7121D6F07B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LamarWithAspNetCore3", "src\LamarWithAspNetCore3\LamarWithAspNetCore3.csproj", "{A513986C-E435-495D-B056-8C7121D6F07B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LamarDiagnosticsWithNetCore3Demonstrator", "src\LamarDiagnosticsWithNetCore3Demonstrator\LamarDiagnosticsWithNetCore3Demonstrator.csproj", "{22B4777B-CF18-4D87-A8DB-684F59F7FC05}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LamarDiagnosticsWithNetCore3Demonstrator", "src\LamarDiagnosticsWithNetCore3Demonstrator\LamarDiagnosticsWithNetCore3Demonstrator.csproj", "{22B4777B-CF18-4D87-A8DB-684F59F7FC05}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LamarCodeGeneration.Commands", "src\LamarCodeGeneration.Commands\LamarCodeGeneration.Commands.csproj", "{7AE3CFA7-64E3-4B31-811D-794AE364AF5F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LamarCodeGeneration.Commands", "src\LamarCodeGeneration.Commands\LamarCodeGeneration.Commands.csproj", "{7AE3CFA7-64E3-4B31-811D-794AE364AF5F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GeneratorTarget", "src\GeneratorTarget\GeneratorTarget.csproj", "{3938B85F-95BA-42F8-B686-DC650C3501A2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GeneratorTarget", "src\GeneratorTarget\GeneratorTarget.csproj", "{3938B85F-95BA-42F8-B686-DC650C3501A2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lamar.AspNetCoreTests.Integration", "src\Lamar.AspNetCoreTests.Integration\Lamar.AspNetCoreTests.Integration.csproj", "{4BA17CD6-53C4-4FFB-8739-A02972AA6A2B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -175,6 +177,10 @@ Global
 		{3938B85F-95BA-42F8-B686-DC650C3501A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3938B85F-95BA-42F8-B686-DC650C3501A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3938B85F-95BA-42F8-B686-DC650C3501A2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4BA17CD6-53C4-4FFB-8739-A02972AA6A2B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4BA17CD6-53C4-4FFB-8739-A02972AA6A2B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4BA17CD6-53C4-4FFB-8739-A02972AA6A2B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4BA17CD6-53C4-4FFB-8739-A02972AA6A2B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Lamar.AspNetCoreTests.Integration/Lamar.AspNetCoreTests.Integration.csproj
+++ b/src/Lamar.AspNetCoreTests.Integration/Lamar.AspNetCoreTests.Integration.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.0.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Lamar.Microsoft.DependencyInjection\Lamar.Microsoft.DependencyInjection.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Lamar.AspNetCoreTests.Integration/MultiThreadProblem/App/Book.cs
+++ b/src/Lamar.AspNetCoreTests.Integration/MultiThreadProblem/App/Book.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Lamar.AspNetCoreTests.Integration.MultiThreadProblem.App
+{
+    public class Book
+    {
+        [Key]
+        public int Id { get; set; }
+
+        public string Title { get; set; }
+
+        public string Author { get; set; }
+    }
+}

--- a/src/Lamar.AspNetCoreTests.Integration/MultiThreadProblem/App/BookController.cs
+++ b/src/Lamar.AspNetCoreTests.Integration/MultiThreadProblem/App/BookController.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace Lamar.AspNetCoreTests.Integration.MultiThreadProblem.App
+{
+    [Route("[controller]")]
+    public class BookController : Controller
+    {
+        private readonly IBookService _bookService;
+        private readonly ILogger<BookController> _logger;
+
+        public BookController(IBookService bookService, ILogger<BookController> logger)
+        {
+            _bookService = bookService;
+            _logger = logger;
+        }
+
+        [HttpGet("InsertAndReturn")]
+        public async Task<IActionResult> InsertAndReturn()
+        {
+            try
+            {
+                var books = await _bookService.InsertBooksAndReturn();
+                return Ok(books);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "error");
+                throw;
+            }
+        }
+    }
+}

--- a/src/Lamar.AspNetCoreTests.Integration/MultiThreadProblem/App/BookService.cs
+++ b/src/Lamar.AspNetCoreTests.Integration/MultiThreadProblem/App/BookService.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+namespace Lamar.AspNetCoreTests.Integration.MultiThreadProblem.App
+{
+    public class BookService : IBookService
+    {
+        private readonly IContextFactory _contextFactory;
+        private readonly IOtherService _otherService;
+        private readonly Context _scopedContext;
+
+        public BookService(IContextFactory contextFactory, Context scopedContext, IOtherService otherService)
+        {
+            _contextFactory = contextFactory;
+            _scopedContext = scopedContext;
+            _otherService = otherService;
+        }
+
+        public async Task<List<Book>> InsertBooksAndReturn()
+        {
+            var tasks = new List<Task>();
+            for (int i = 0; i < 25; i++)
+            {
+                tasks.Add(CreateBook());
+            }
+
+            await Task.WhenAll(tasks);
+            await _otherService.AddBunchOfBooks();
+            return await _scopedContext.Book.Take(100).ToListAsync();
+        }
+
+        private async Task CreateBook()
+        {
+            using (var context = _contextFactory.CreateNewContext())
+            {
+                context.Add(new Book {Author = Guid.NewGuid().ToString(), Title = Guid.NewGuid().ToString()});
+                await Task.Delay(3000);
+                await context.SaveChangesAsync();
+            }
+        }
+    }
+}

--- a/src/Lamar.AspNetCoreTests.Integration/MultiThreadProblem/App/Context.cs
+++ b/src/Lamar.AspNetCoreTests.Integration/MultiThreadProblem/App/Context.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Lamar.AspNetCoreTests.Integration.MultiThreadProblem.App
+{
+    public class Context : DbContext
+    {
+        private readonly SecondContext _secondContext;
+        public static InMemoryDatabaseRoot DatabaseRoot => new InMemoryDatabaseRoot();
+
+        public Context(SecondContext secondContext)
+        {
+            _secondContext = secondContext;
+        }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            if (!optionsBuilder.IsConfigured)
+            {
+                optionsBuilder.UseInMemoryDatabase("db", databaseRoot: DatabaseRoot)
+                    .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+            }
+        }
+
+        public SecondContext SecondContext { get; set; }
+
+        public int RandomProperty => _secondContext.RandomProperty;
+
+        public DbSet<Book> Book { get; set; }
+    }
+}

--- a/src/Lamar.AspNetCoreTests.Integration/MultiThreadProblem/App/ContextFactory.cs
+++ b/src/Lamar.AspNetCoreTests.Integration/MultiThreadProblem/App/ContextFactory.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Lamar.AspNetCoreTests.Integration.MultiThreadProblem.App
+{
+    public class ContextFactory : IContextFactory
+    {
+        private readonly Context _scopedContext;
+
+        public ContextFactory(Context scopedContext)
+        {
+            _scopedContext = scopedContext;
+        }
+
+        public Context CreateNewContext()
+        {
+            var newContext = new Context(_scopedContext.SecondContext);
+            return newContext;
+        }
+    }
+}

--- a/src/Lamar.AspNetCoreTests.Integration/MultiThreadProblem/App/IBookService.cs
+++ b/src/Lamar.AspNetCoreTests.Integration/MultiThreadProblem/App/IBookService.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Lamar.AspNetCoreTests.Integration.MultiThreadProblem.App
+{
+    public interface IBookService
+    {
+        Task<List<Book>> InsertBooksAndReturn();
+    }
+}

--- a/src/Lamar.AspNetCoreTests.Integration/MultiThreadProblem/App/IContextFactory.cs
+++ b/src/Lamar.AspNetCoreTests.Integration/MultiThreadProblem/App/IContextFactory.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Lamar.AspNetCoreTests.Integration.MultiThreadProblem.App
+{
+    public interface IContextFactory
+    {
+        Context CreateNewContext();
+    }
+}

--- a/src/Lamar.AspNetCoreTests.Integration/MultiThreadProblem/App/IOtherService.cs
+++ b/src/Lamar.AspNetCoreTests.Integration/MultiThreadProblem/App/IOtherService.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Lamar.AspNetCoreTests.Integration.MultiThreadProblem.App
+{
+    public interface IOtherService
+    {
+        Task AddBunchOfBooks();
+    }
+}

--- a/src/Lamar.AspNetCoreTests.Integration/MultiThreadProblem/App/LamarStartup.cs
+++ b/src/Lamar.AspNetCoreTests.Integration/MultiThreadProblem/App/LamarStartup.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Lamar.AspNetCoreTests.Integration.MultiThreadProblem.App
+{
+    public class LamarStartup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddDbContext<Context>();
+            services.AddDbContext<SecondContext>();
+
+            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
+        }
+
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            app.UseRouting();
+            app.UseEndpoints(configure => configure.MapControllers());
+        }
+
+        public void ConfigureContainer(ServiceRegistry services)
+        {
+            services.For<IBookService>().Use<BookService>().Transient();
+            services.For<IOtherService>().Use<OtherService>().Transient();
+            services.For<IContextFactory>().Use<ContextFactory>().Transient();
+        }
+    }
+}

--- a/src/Lamar.AspNetCoreTests.Integration/MultiThreadProblem/App/MicrosoftDIStartup.cs
+++ b/src/Lamar.AspNetCoreTests.Integration/MultiThreadProblem/App/MicrosoftDIStartup.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Lamar.AspNetCoreTests.Integration.MultiThreadProblem.App
+{
+    public class MicrosoftDIStartup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddDbContext<Context>();
+            services.AddDbContext<SecondContext>();
+
+            services.AddTransient<IBookService, BookService>();
+            services.AddTransient<IOtherService, OtherService>();
+            services.AddTransient<IContextFactory, ContextFactory>();
+
+            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
+        }
+
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            app.UseRouting();
+            app.UseEndpoints(configure => configure.MapControllers());
+        }
+    }
+}

--- a/src/Lamar.AspNetCoreTests.Integration/MultiThreadProblem/App/OtherService.cs
+++ b/src/Lamar.AspNetCoreTests.Integration/MultiThreadProblem/App/OtherService.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Lamar.AspNetCoreTests.Integration.MultiThreadProblem.App
+{
+    public class OtherService : IOtherService
+    {
+        private readonly Context _scopedContext;
+
+        public OtherService(Context scopedContext)
+        {
+            _scopedContext = scopedContext;
+        }
+
+        public async Task AddBunchOfBooks()
+        {
+            for (int i = 0; i < 30; i++)
+            {
+                await Task.Delay(1000);
+                _scopedContext.Add(new Book
+                {
+                    Author = Guid.NewGuid().ToString(),
+                    Title = Guid.NewGuid().ToString()
+                });
+            }
+
+            await _scopedContext.SaveChangesAsync();
+        }
+    }
+}

--- a/src/Lamar.AspNetCoreTests.Integration/MultiThreadProblem/App/SecondContext.cs
+++ b/src/Lamar.AspNetCoreTests.Integration/MultiThreadProblem/App/SecondContext.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Diagnostics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+namespace Lamar.AspNetCoreTests.Integration.MultiThreadProblem.App
+{
+    public class SecondContext : DbContext
+    {
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            if (!optionsBuilder.IsConfigured)
+            {
+                optionsBuilder.UseInMemoryDatabase("db", databaseRoot: Context.DatabaseRoot)
+                    .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+            }
+        }
+
+        public int RandomProperty => 5;
+
+        public DbSet<Book> Book { get; set; }
+    }
+}

--- a/src/Lamar.AspNetCoreTests.Integration/MultiThreadProblem/CustomWebApplicationFactory.cs
+++ b/src/Lamar.AspNetCoreTests.Integration/MultiThreadProblem/CustomWebApplicationFactory.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Lamar.AspNetCoreTests.Integration.MultiThreadProblem.App;
+using Lamar.Microsoft.DependencyInjection;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Lamar.AspNetCoreTests.Integration.MultiThreadProblem
+{
+    public class CustomWebApplicationFactory<T> : WebApplicationFactory<T> where T : class
+    {
+        public bool UseLamar { get; set; }
+
+        protected override IHostBuilder CreateHostBuilder()
+        {
+            var builder = Host.CreateDefaultBuilder().ConfigureWebHostDefaults(webBuilder => webBuilder.UseStartup<T>());
+            return UseLamar ? builder.UseLamar() : builder;
+        }
+
+        protected override IWebHostBuilder CreateWebHostBuilder()
+        {
+            return WebHost.CreateDefaultBuilder(null)
+                .UseStartup<T>();
+        }
+    }
+}

--- a/src/Lamar.AspNetCoreTests.Integration/MultiThreadProblem/IntegrationTests.cs
+++ b/src/Lamar.AspNetCoreTests.Integration/MultiThreadProblem/IntegrationTests.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Lamar.AspNetCoreTests.Integration.MultiThreadProblem.App;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.DependencyInjection;
+using Lamar.Microsoft.DependencyInjection;
+using Xunit;
+
+namespace Lamar.AspNetCoreTests.Integration.MultiThreadProblem
+{
+    public class IntegrationTestsMicrosoftDI : IClassFixture<CustomWebApplicationFactory<MicrosoftDIStartup>>
+    {
+        private readonly WebApplicationFactory<MicrosoftDIStartup> _factory;
+
+        public IntegrationTestsMicrosoftDI(CustomWebApplicationFactory<MicrosoftDIStartup> factory)
+        {
+            factory.UseLamar = false;
+            _factory = factory.WithWebHostBuilder(builder =>
+            {
+                builder.UseSolutionRelativeContentRoot(@"src\Lamar.AspNetCoreTests.Integration");
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddControllers();
+                });
+            });
+        }
+
+        [Fact]
+        public async void ExecutesInParallel_WithoutExceptions()
+        {
+            var client = _factory.CreateClient();
+            var tasks = new List<Task>();
+            for (int i = 0; i < 5; i++)
+            {
+                tasks.Add(client.GetAsync("Book/InsertAndReturn"));
+            }
+
+            await Task.WhenAll(tasks);
+        }
+    }
+
+    public class IntegrationTestsLamar : IClassFixture<CustomWebApplicationFactory<LamarStartup>>
+    {
+        private readonly WebApplicationFactory<LamarStartup> _factory;
+
+        public IntegrationTestsLamar(CustomWebApplicationFactory<LamarStartup> factory)
+        {
+            factory.UseLamar = true;
+            _factory = factory.WithWebHostBuilder(builder =>
+            {
+                builder.UseSolutionRelativeContentRoot(@"src\Lamar.AspNetCoreTests.Integration");
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddControllers();
+                });
+            });
+        }
+
+        [Fact]
+        public async void ExecutesInParallel_WithoutExceptions()
+        {
+            var client = _factory.CreateClient();
+            var tasks = new List<Task>();
+            for (int i = 0; i < 5; i++)
+            {
+                tasks.Add(client.GetAsync("Book/InsertAndReturn"));
+            }
+
+            await Task.WhenAll(tasks);
+        }
+    }
+}


### PR DESCRIPTION
Added two unit tests that demonstrate the scoping issue described in https://github.com/JasperFx/lamar/issues/198. The Microsoft example passes whereas the Lamar one fails with DbContext threading exceptions