### PR TITLE
#203 Add IWebHostBuilder to .NET Standard 2.1

### DIFF
--- a/src/Lamar.Microsoft.DependencyInjection/Lamar.Microsoft.DependencyInjection.csproj
+++ b/src/Lamar.Microsoft.DependencyInjection/Lamar.Microsoft.DependencyInjection.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="[2.1.0,3.0)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.1.0,3.0)" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="[3.0.0,4.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="[3.0.0,4.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="[3.0.0,4.0.0)" />

--- a/src/Lamar.Microsoft.DependencyInjection/WebHostBuilderExtensions.cs
+++ b/src/Lamar.Microsoft.DependencyInjection/WebHostBuilderExtensions.cs
@@ -1,21 +1,16 @@
-﻿#if NETSTANDARD2_0
-using Microsoft.AspNetCore.Hosting;
-#endif
+﻿using Microsoft.AspNetCore.Hosting;
 using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
-
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-
 
 namespace Lamar.Microsoft.DependencyInjection
 {
 
     public static class WebHostBuilderExtensions
     {
-        #if NETSTANDARD2_0
         public static IWebHostBuilder UseLamar<T>(this IWebHostBuilder builder, Action<WebHostBuilderContext, T> configure = null) where T : ServiceRegistry, new()
         {
             return builder.ConfigureServices((context, services) =>
@@ -36,8 +31,6 @@ namespace Lamar.Microsoft.DependencyInjection
         {
             return builder.ConfigureServices((context, services) => { services.AddLamar(registry); });
         }
-        #endif
-        
 
         /// <summary>
         /// Shortcut to replace the built in DI container with Lamar using the extra service registrations


### PR DESCRIPTION
Fixes #203 which will allow the IWebHostBuilder to be used for registrations. This can be used in projects that use the Amazon.Lambda.RuntimeSupport.

 https://aws.amazon.com/blogs/developer/net-core-3-0-on-lambda-with-aws-lambdas-custom-runtime/
