### PR TITLE
Index out of range when using GetInstance(type)

### DIFF
--- a/src/Lamar.Testing/IoC/Acceptance/disposing_container.cs
+++ b/src/Lamar.Testing/IoC/Acceptance/disposing_container.cs
@@ -1,5 +1,6 @@
 ﻿using Shouldly;
 using System;
+using System.Threading.Tasks;
 using Baseline;
 using Lamar;
 using Lamar.Testing;
@@ -178,6 +179,20 @@ namespace StructureMap.Testing.Pipeline
 
             disposableDependent.WasDisposed.ShouldBeTrue();
             disposableDependent.ChildDisposable.WasDisposed.ShouldBeTrue();
+        }
+        
+        [Fact]
+        public void should_work_when_get_disposables_in_parallel()
+        {
+            var container = new Container(x => { x.For<I1>().Use(_ => new C1Yes()).Transient(); });
+
+            Parallel.For(0, 1000,
+                (i) =>
+                {
+                    container.GetInstance<DisposableDependent>();
+                });
+            
+            container.Dispose();
         }
         
         [Fact]

--- a/src/Lamar/IoC/Instances/ConstructorInstance.cs
+++ b/src/Lamar/IoC/Instances/ConstructorInstance.cs
@@ -125,17 +125,11 @@ namespace Lamar.IoC.Instances
             {
                 if (Lifetime == ServiceLifetime.Singleton)
                 {
-                    if (!scope.Root.Disposables.Contains(disposable))
-                    {
-                        scope.Root.Disposables.Add(disposable);
-                    }
+                    scope.Root.Disposables.Add(disposable);
                 }
                 else
                 {
-                    if (!scope.Disposables.Contains(disposable))
-                    {
-                        scope.Disposables.Add(disposable);
-                    }
+                    scope.Disposables.Add(disposable);
                 }
                 
             }

--- a/src/Lamar/IoC/Instances/ConstructorInstance.cs
+++ b/src/Lamar/IoC/Instances/ConstructorInstance.cs
@@ -125,11 +125,17 @@ namespace Lamar.IoC.Instances
             {
                 if (Lifetime == ServiceLifetime.Singleton)
                 {
-                    scope.Root.Disposables.Fill(disposable);
+                    if (!scope.Root.Disposables.Contains(disposable))
+                    {
+                        scope.Root.Disposables.Add(disposable);
+                    }
                 }
                 else
                 {
-                    scope.Disposables.Fill(disposable);
+                    if (!scope.Disposables.Contains(disposable))
+                    {
+                        scope.Disposables.Add(disposable);
+                    }
                 }
                 
             }

--- a/src/Lamar/IoC/Instances/LambdaDefinitionExtensions.cs
+++ b/src/Lamar/IoC/Instances/LambdaDefinitionExtensions.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -13,7 +13,7 @@ namespace Lamar.IoC.Instances
         private static readonly MethodInfo _getDisposables =
             ReflectionHelper.GetProperty<Scope>(x => x.Disposables).GetGetMethod();
 
-        private static readonly MethodInfo _add = ReflectionHelper.GetMethod<List<IDisposable>>(x => x.Add(null));
+        private static readonly MethodInfo _add = ReflectionHelper.GetMethod<ConcurrentBag<IDisposable>>(x => x.Add(null));
 
         private static readonly MethodInfo _tryRegisterDisposable =
             ReflectionHelper.GetMethod<Scope>(x => x.TryAddDisposable(null));

--- a/src/Lamar/IoC/Scope.cs
+++ b/src/Lamar/IoC/Scope.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -97,7 +98,7 @@ namespace Lamar.IoC
         internal ServiceGraph ServiceGraph { get; set;}
 
 
-        public List<IDisposable> Disposables { get; } = new List<IDisposable>();
+        public ConcurrentBag<IDisposable> Disposables { get; } = new ConcurrentBag<IDisposable>();
 
         internal readonly Dictionary<int, object> Services = new Dictionary<int, object>();
 

--- a/src/Lamar/IoC/Scope.cs
+++ b/src/Lamar/IoC/Scope.cs
@@ -113,7 +113,7 @@ namespace Lamar.IoC
             if (_hasDisposed) return;
             _hasDisposed = true;
 
-            foreach (var disposable in Disposables)
+            foreach (var disposable in Disposables.Distinct())
             {
                 disposable.SafeDispose();
             }


### PR DESCRIPTION
Fixes #186.
Use ConcurrentBag instead of List, because Disposables collection might be called from multiple threads and it should be thread-safe