### PR TITLE
Simple convenience method to include an instance of a registry

### DIFF
--- a/src/Lamar/ServiceRegistry.cs
+++ b/src/Lamar/ServiceRegistry.cs
@@ -263,10 +263,14 @@ namespace Lamar
             Add(descriptor);
         }
 
-
         public void IncludeRegistry<T>() where T : ServiceRegistry, new()
         {
             this.AddRange(new T());
+        }
+
+        public void IncludeRegistry<T>(T serviceRegistry) where T : ServiceRegistry
+        {
+            this.AddRange(serviceRegistry);
         }
 
         /// <summary>


### PR DESCRIPTION
This is something I run into occasionally, usually to do with limitations elsewhere in .NET Core around passing configuration values into a registry so that it can register different things based on the current environment (eg. using a local file store for dev, but a cloud storage provider for production environments).