### PR TITLE
Fix subsequent configures

### DIFF
--- a/src/Lamar.Testing/IoC/Acceptance/configure_container.cs
+++ b/src/Lamar.Testing/IoC/Acceptance/configure_container.cs
@@ -25,7 +25,7 @@ namespace Lamar.Testing.IoC.Acceptance
         // ENDSAMPLE
 
         [Fact]
-        public void add_consumed_service_laster()
+        public void add_consumed_service_later()
         {
             var container = new Container(_ =>
             {

--- a/src/Lamar.Testing/IoC/Acceptance/configure_container.cs
+++ b/src/Lamar.Testing/IoC/Acceptance/configure_container.cs
@@ -23,7 +23,23 @@ namespace Lamar.Testing.IoC.Acceptance
                 .ShouldBeOfType<WhateverService>();
         }
         // ENDSAMPLE
-        
+
+        [Fact]
+        public void add_consumed_service_laster()
+        {
+            var container = new Container(_ =>
+            {
+                _.AddTransient<WidgetUser>();
+            });
+            container.Configure(services =>
+            {
+                services.AddTransient<IWidget, RedWidget>();
+            });
+            var instance = container.GetInstance<WidgetUser>();
+            instance.ShouldBeOfType<WidgetUser>();
+            instance.Widget.ShouldBeOfType<RedWidget>();
+        }
+
         [Fact]
         public void add_to_existing_family()
         {

--- a/src/Lamar/IoC/Instances/Instance.cs
+++ b/src/Lamar/IoC/Instances/Instance.cs
@@ -138,6 +138,8 @@ namespace Lamar.IoC.Instances
 
         public bool HasPlanned { get; protected internal set; }
 
+        public bool PlanningSucceeded { get; protected internal set; }
+
         public void CreatePlan(ServiceGraph services)
         {
             if (HasPlanned) return;
@@ -184,7 +186,16 @@ namespace Lamar.IoC.Instances
             }
 
             services.ClearPlanning();
+
+            PlanningSucceeded = ErrorMessages.Count == 0;
             HasPlanned = true;
+        }
+
+        internal virtual void Reset()
+        {
+            HasPlanned = false;
+            PlanningSucceeded = false;
+            ErrorMessages.Clear();
         }
 
 

--- a/src/Lamar/IoC/Instances/Instance.cs
+++ b/src/Lamar/IoC/Instances/Instance.cs
@@ -191,7 +191,7 @@ namespace Lamar.IoC.Instances
             HasPlanned = true;
         }
 
-        internal virtual void Reset()
+        public virtual void Reset()
         {
             HasPlanned = false;
             PlanningSucceeded = false;

--- a/src/Lamar/ServiceGraph.cs
+++ b/src/Lamar/ServiceGraph.cs
@@ -168,6 +168,10 @@ namespace Lamar
 
         private void planResolutionStrategies()
         {
+            foreach (var instance in AllInstances().Where(x => x.HasPlanned && !x.PlanningSucceeded).ToArray())
+            {
+                instance.Reset();
+            }
             while (AllInstances().Where(x => !x.ServiceType.IsOpenGeneric()).Any(x => !x.HasPlanned))
             {
                 foreach (var instance in AllInstances().Where(x => !x.HasPlanned).ToArray())
@@ -456,7 +460,6 @@ namespace Lamar
 
                 registry
                     .Where(x => !x.ServiceType.HasAttribute<LamarIgnoreAttribute>())
-
                     .GroupBy(x => x.ServiceType)
                     .Each(group =>
                     {

--- a/src/Lamar/ServiceGraph.cs
+++ b/src/Lamar/ServiceGraph.cs
@@ -166,12 +166,16 @@ namespace Lamar
 
         private bool _inPlanning = false;
 
-        private void planResolutionStrategies()
+        private void resetInstancePlanning()
         {
-            foreach (var instance in AllInstances().Where(x => x.HasPlanned && !x.PlanningSucceeded).ToArray())
+            foreach (var instance in AllInstances())
             {
                 instance.Reset();
             }
+        }
+
+        private void planResolutionStrategies()
+        {
             while (AllInstances().Where(x => !x.ServiceType.IsOpenGeneric()).Any(x => !x.HasPlanned))
             {
                 foreach (var instance in AllInstances().Where(x => !x.HasPlanned).ToArray())
@@ -478,6 +482,8 @@ namespace Lamar
                             _families.Add(@group.Key, family);
                         }
                     });
+
+                resetInstancePlanning();
 
                 buildOutMissingResolvers();
             


### PR DESCRIPTION
Fixes #247 

This is a simple, and possibly naive solution, but essentially allows instances that failed to plan properly on container construction to be retried on subsequent container Configure calls. 

Wrote a test to match.