### PR TITLE
Net5.0 support

### DIFF
--- a/Widget.Core/Widget.Core.csproj
+++ b/Widget.Core/Widget.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Widget.Instance/Widget.Instance.csproj
+++ b/Widget.Instance/Widget.Instance.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Widget.Registration/Widget.Registration.csproj
+++ b/Widget.Registration/Widget.Registration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 4.3.0.{build}
 
 configuration: Release
 
-os: Visual Studio 2017
+os: Visual Studio 2019
 
 environment:
   DOTNET_CLI_TELEMETRY_OPTOUT: true

--- a/src/Aspect.Logger/Widget.Aspect.Logger.csproj
+++ b/src/Aspect.Logger/Widget.Aspect.Logger.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GeneratorTarget/GeneratorTarget.csproj
+++ b/src/GeneratorTarget/GeneratorTarget.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFrameworks>netcoreapp3.0;net5.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Lamar.AspNetCoreTests.Integration/Lamar.AspNetCoreTests.Integration.csproj
+++ b/src/Lamar.AspNetCoreTests.Integration/Lamar.AspNetCoreTests.Integration.csproj
@@ -1,17 +1,29 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.0;net5.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.0.0" />
+    <PackageReference Include="Shouldly" Version="3.0.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="[5.0.0,5.9.0)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[5.0.0,5.9.0)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[5.0.0,5.9.0)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="[5.0.0,5.9.0)" />
     <PackageReference Include="Shouldly" Version="3.0.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/src/Lamar.AspNetCoreTests/Lamar.AspNetCoreTests.csproj
+++ b/src/Lamar.AspNetCoreTests/Lamar.AspNetCoreTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2;netcoreapp3.1;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
@@ -36,6 +36,17 @@
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.6" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.6" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="App.Metrics.AspNetCore.Mvc" Version="4.1.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI" Version="5.0.0-preview1" />
+    <PackageReference Include="Baseline" Version="2.1.1" />
+    <PackageReference Include="IdentityServer4" Version="4.0.2" />
+    <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.HealthChecks" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="[5.0.0,5.9.0)" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[5.0.0,5.9.0)" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Lamar.Diagnostics/Lamar.Diagnostics.csproj
+++ b/src/Lamar.Diagnostics/Lamar.Diagnostics.csproj
@@ -2,9 +2,9 @@
 
     <PropertyGroup>
         <Description>Adds diagnostic checks to the command line of your Lamar-enabled ASP.Net Core app</Description>
-        <VersionPrefix>1.1.8</VersionPrefix>
+        <VersionPrefix>1.1.9</VersionPrefix>
         <Authors>Jeremy D. Miller</Authors>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
         <DebugType>portable</DebugType>
         <AssemblyName>Lamar.Diagnostics</AssemblyName>
         <PackageId>Lamar.Diagnostics</PackageId>
@@ -18,10 +18,22 @@
         <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
     </PropertyGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
          <ProjectReference Include="..\Lamar\Lamar.csproj" />
-         <PackageReference Include="BaselineTypeDiscovery" Version="1.1.0" />
+         <PackageReference Include="BaselineTypeDiscovery" Version="1.1.1" />
          <PackageReference Include="Oakton.AspNetCore" Version="2.1.3" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+      <ProjectReference Include="..\Lamar\Lamar.csproj" />
+      <PackageReference Include="BaselineTypeDiscovery" Version="1.1.1" />
+      <PackageReference Include="Oakton.AspNetCore" Version="2.1.3" />
+    </ItemGroup>
+  
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+      <ProjectReference Include="..\Lamar\Lamar.csproj" />
+      <PackageReference Include="BaselineTypeDiscovery" Version="1.1.1" />
+      <PackageReference Include="Oakton.AspNetCore" Version="2.1.5" />
     </ItemGroup>
 
 </Project>

--- a/src/Lamar.Microsoft.DependencyInjection/Lamar.Microsoft.DependencyInjection.csproj
+++ b/src/Lamar.Microsoft.DependencyInjection/Lamar.Microsoft.DependencyInjection.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Lamar Adapter for ASP.Net Core</Description>
-    <VersionPrefix>4.4.0</VersionPrefix>
+    <VersionPrefix>4.4.1</VersionPrefix>
     <Authors>Jeremy D. Miller</Authors>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>Lamar.Microsoft.DependencyInjection</AssemblyName>
     <PackageId>Lamar.Microsoft.DependencyInjection</PackageId>
@@ -47,5 +47,12 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="[3.0.0,5.9.0)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="[3.0.0,5.9.0)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="[3.0.0,5.9.0)" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.2.0, 3.0)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[5.0.0,5.9.0)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="[5.0.0,5.9.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="[5.0.0,5.9.0)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="[5.0.0,5.9.0)" />
   </ItemGroup>
 </Project>

--- a/src/Lamar.Testing/Lamar.Testing.csproj
+++ b/src/Lamar.Testing/Lamar.Testing.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;net48;netcoreapp2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;net48;netcoreapp2.0;netcoreapp2.1;netcoreapp3.0;net5.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Baseline" Version="1.5.0" />
-    
     <PackageReference Include="System.Data.SqlClient" Version="4.5.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
@@ -34,11 +33,21 @@
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.2" />
+    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="Baseline" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
   </ItemGroup>
   

--- a/src/Lamar/IoC/Diagnostics/ModelQuery.cs
+++ b/src/Lamar/IoC/Diagnostics/ModelQuery.cs
@@ -19,7 +19,7 @@ namespace Lamar.IoC.Diagnostics
 
             if (Namespace.IsNotEmpty())
             {
-                enumerable = enumerable.Where(x => TypeExtensions.IsInNamespace(x.ServiceType, Namespace));
+                enumerable = enumerable.Where(x => LamarCodeGeneration.Util.TypeExtensions.IsInNamespace(x.ServiceType, Namespace));
             }
 
             if (ServiceType != null)

--- a/src/Lamar/Lamar.csproj
+++ b/src/Lamar/Lamar.csproj
@@ -45,6 +45,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="BaselineTypeDiscovery" Version="1.1.1" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5.0.0, 5.9.0)" />
   </ItemGroup>

--- a/src/Lamar/Lamar.csproj
+++ b/src/Lamar/Lamar.csproj
@@ -16,30 +16,33 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="BaselineTypeDiscovery" Version="1.1.0" />
-  </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\LamarCodeGeneration\LamarCodeGeneration.csproj" />
   </ItemGroup>
+  
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'net48' ">
     <DefineConstants>$(DefineConstants);NET4x</DefineConstants>
   </PropertyGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <PackageReference Include="BaselineTypeDiscovery" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[2.0.0, 3.0.0)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
+    <PackageReference Include="BaselineTypeDiscovery" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[2.0.0, 5.9.0)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="BaselineTypeDiscovery" Version="1.1.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[2.0.0, 5.9.0)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+    <PackageReference Include="BaselineTypeDiscovery" Version="1.1.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.0.0, 5.9.0)" />
   </ItemGroup>

--- a/src/Lamar/Lamar.csproj
+++ b/src/Lamar/Lamar.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Fast ASP.Net Core compatible IoC Tool, Successor to StructureMap</Description>
-    <VersionPrefix>4.4.0</VersionPrefix>
+    <VersionPrefix>4.4.1</VersionPrefix>
     <Authors>Jeremy D. Miller</Authors>
-    <TargetFrameworks>net461;net48;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net461;net48;netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>Lamar</AssemblyName>
     <PackageId>Lamar</PackageId>
@@ -42,5 +42,10 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.0.0, 5.9.0)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5.0.0, 5.9.0)" />
   </ItemGroup>
 </Project>

--- a/src/LamarCodeGeneration.Commands/LamarCodeGeneration.Commands.csproj
+++ b/src/LamarCodeGeneration.Commands/LamarCodeGeneration.Commands.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
@@ -24,7 +24,11 @@
       <ProjectReference Include="..\LamarCompiler\LamarCompiler.csproj" />
     </ItemGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+      <PackageReference Include="Oakton.AspNetCore" Version="2.1.3" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
       <PackageReference Include="Oakton.AspNetCore" Version="2.1.3" />
     </ItemGroup>
 

--- a/src/LamarCodeGeneration.Commands/LamarCodeGeneration.Commands.csproj
+++ b/src/LamarCodeGeneration.Commands/LamarCodeGeneration.Commands.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
 
         <Description>Command line utilities for managing Lamar dynamically generated code</Description>
-        <VersionPrefix>1.1.2</VersionPrefix>
+        <VersionPrefix>1.1.3</VersionPrefix>
         <Authors>Jeremy D. Miller</Authors>
         <DebugType>portable</DebugType>
         <AssemblyName>LamarCodeGeneration.Commands</AssemblyName>
@@ -26,6 +26,10 @@
 
     <ItemGroup>
       <PackageReference Include="Oakton.AspNetCore" Version="2.1.3" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+      <PackageReference Include="Oakton.AspNetCore" Version="2.1.5" />
     </ItemGroup>
 
 </Project>

--- a/src/LamarCodeGeneration/LamarCodeGeneration.csproj
+++ b/src/LamarCodeGeneration/LamarCodeGeneration.csproj
@@ -2,9 +2,9 @@
 
     <PropertyGroup>
         <Description>Code Generation Chicanery for .Net</Description>
-        <VersionPrefix>2.5.0</VersionPrefix>
+        <VersionPrefix>2.5.1</VersionPrefix>
         <Authors>Jeremy D. Miller</Authors>
-        <TargetFrameworks>net461;net48;netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net461;net48;netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
         <DebugType>portable</DebugType>
         <AssemblyName>LamarCodeGeneration</AssemblyName>
         <PackageId>LamarCodeGeneration</PackageId>

--- a/src/LamarCompiler.Testing/LamarCompiler.Testing.csproj
+++ b/src/LamarCompiler.Testing/LamarCompiler.Testing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net48;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;net48;netcoreapp2.1;netcoreapp3.0;net5.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -15,6 +15,10 @@
     <PackageReference Include="Baseline" Version="2.1.0" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="Baseline" Version="2.1.1" />
+  </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\LamarCompiler\LamarCompiler.csproj" />
     <ProjectReference Include="..\Lamar\Lamar.csproj" />

--- a/src/LamarCompiler/LamarCompiler.csproj
+++ b/src/LamarCompiler/LamarCompiler.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Runtime Roslyn Compilation and Code Generation Chicanery</Description>
-    <VersionPrefix>2.3.1</VersionPrefix>
+    <VersionPrefix>2.3.2</VersionPrefix>
     <Authors>Jeremy D. Miller</Authors>
-    <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>LamarCompiler</AssemblyName>
     <PackageId>LamarCompiler</PackageId>
@@ -26,6 +26,10 @@
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
   </ItemGroup>

--- a/src/LamarDiagnosticsWithNetCore3Demonstrator/LamarDiagnosticsWithNetCore3Demonstrator.csproj
+++ b/src/LamarDiagnosticsWithNetCore3Demonstrator/LamarDiagnosticsWithNetCore3Demonstrator.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFrameworks>netcoreapp3.0;net5.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
@@ -10,8 +10,11 @@
       <ProjectReference Include="..\Lamar.Microsoft.DependencyInjection\Lamar.Microsoft.DependencyInjection.csproj" />
     </ItemGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.0" />
     </ItemGroup>
 
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+    </ItemGroup>
 </Project>

--- a/src/LamarRest.Testing/LamarRest.Testing.csproj
+++ b/src/LamarRest.Testing/LamarRest.Testing.csproj
@@ -1,27 +1,34 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFrameworks>netcoreapp2.2;net5.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Baseline" Version="1.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="Shouldly" Version="3.0.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.2' ">
+    <PackageReference Include="Baseline" Version="1.5.0" />
+  </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="Baseline" Version="2.1.1" />
+  </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\Lamar.Microsoft.DependencyInjection\Lamar.Microsoft.DependencyInjection.csproj" />
     <ProjectReference Include="..\LamarRest\LamarRest.csproj" />
     <ProjectReference Include="..\UserApp\UserApp.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.2' ">
     <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/src/LamarRest/LamarRest.csproj
+++ b/src/LamarRest/LamarRest.csproj
@@ -1,16 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Baseline" Version="1.5.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="Baseline" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+  </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\LamarCompiler\LamarCompiler.csproj" />
     <ProjectReference Include="..\Lamar\Lamar.csproj" />

--- a/src/LamarWithAspNetCore3/LamarWithAspNetCore3.csproj
+++ b/src/LamarWithAspNetCore3/LamarWithAspNetCore3.csproj
@@ -1,25 +1,33 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFrameworks>netcoreapp3.0;net5.0</TargetFrameworks>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <FrameworkReference Include="Microsoft.AspNetCore.App" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-        <PackageReference Include="xunit" Version="2.4.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-        <PackageReference Include="coverlet.collector" Version="1.0.1" />
-        <PackageReference Include="Shouldly" Version="3.0.0" />
+      <FrameworkReference Include="Microsoft.AspNetCore.App" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+      <PackageReference Include="xunit" Version="2.4.0" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+      <PackageReference Include="coverlet.collector" Version="1.0.1" />
+      <PackageReference Include="Shouldly" Version="3.0.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Baseline" Version="1.5.0" />
       <ProjectReference Include="..\Lamar.Microsoft.DependencyInjection\Lamar.Microsoft.DependencyInjection.csproj" />
       <ProjectReference Include="..\StructureMap.Testing.Widget\StructureMap.Testing.Widget.csproj" />
     </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
+    <PackageReference Include="Baseline" Version="1.5.0" />
+  </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+      <PackageReference Include="Baseline" Version="2.1.1" />
+    </ItemGroup>
+  
     <ItemGroup>
         <None Update="appsettings.json">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/LamarWithAspNetCoreMvc3/LamarWithAspNetCoreMvc3.csproj
+++ b/src/LamarWithAspNetCoreMvc3/LamarWithAspNetCoreMvc3.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFrameworks>netcoreapp3.0;net5.0</TargetFrameworks>
     </PropertyGroup>
 
 

--- a/src/SampleWebApp/SampleWebApp.csproj
+++ b/src/SampleWebApp/SampleWebApp.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;net5.0</TargetFrameworks>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 

--- a/src/SampleWorkerApp/SampleWorkerApp.csproj
+++ b/src/SampleWorkerApp/SampleWorkerApp.csproj
@@ -1,14 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <UserSecretsId>dotnet-SampleWorkerApp-BCF1B093-F477-44E3-9B2D-66276CD46043</UserSecretsId>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.1" />
   </ItemGroup>
 
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+  </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\Lamar.Diagnostics\Lamar.Diagnostics.csproj" />
     <ProjectReference Include="..\Lamar.Microsoft.DependencyInjection\Lamar.Microsoft.DependencyInjection.csproj" />

--- a/src/StructureMap.Testing.ExeWidget/StructureMap.Testing.ExeWidget.csproj
+++ b/src/StructureMap.Testing.ExeWidget/StructureMap.Testing.ExeWidget.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net5.0</TargetFrameworks>
     <AssemblyName>StructureMap.Testing.ExeWidget</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>StructureMap.Testing.ExeWidget</PackageId>

--- a/src/StructureMap.Testing.GenericWidgets/StructureMap.Testing.GenericWidgets.csproj
+++ b/src/StructureMap.Testing.GenericWidgets/StructureMap.Testing.GenericWidgets.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
     <AssemblyName>StructureMap.Testing.GenericWidgets</AssemblyName>
     <PackageId>StructureMap.Testing.GenericWidgets</PackageId>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/src/StructureMap.Testing.Widget/StructureMap.Testing.Widget.csproj
+++ b/src/StructureMap.Testing.Widget/StructureMap.Testing.Widget.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
     <AssemblyName>StructureMap.Testing.Widget</AssemblyName>
     <PackageId>StructureMap.Testing.Widget</PackageId>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/src/StructureMap.Testing.Widget2/StructureMap.Testing.Widget2.csproj
+++ b/src/StructureMap.Testing.Widget2/StructureMap.Testing.Widget2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
     <AssemblyName>StructureMap.Testing.Widget2</AssemblyName>
     <PackageId>StructureMap.Testing.Widget2</PackageId>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/src/StructureMap.Testing.Widget3/StructureMap.Testing.Widget3.csproj
+++ b/src/StructureMap.Testing.Widget3/StructureMap.Testing.Widget3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
     <AssemblyName>StructureMap.Testing.Widget3</AssemblyName>
     <PackageId>StructureMap.Testing.Widget3</PackageId>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/src/StructureMap.Testing.Widget4/StructureMap.Testing.Widget4.csproj
+++ b/src/StructureMap.Testing.Widget4/StructureMap.Testing.Widget4.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
     <AssemblyName>StructureMap.Testing.Widget4</AssemblyName>
     <PackageId>StructureMap.Testing.Widget4</PackageId>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.5' ">1.6.0</NetStandardImplicitPackageVersion>

--- a/src/StructureMap.Testing.Widget5/StructureMap.Testing.Widget5.csproj
+++ b/src/StructureMap.Testing.Widget5/StructureMap.Testing.Widget5.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
     <AssemblyName>StructureMap.Testing.Widget5</AssemblyName>
     <PackageId>StructureMap.Testing.Widget5</PackageId>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/src/UserApp/UserApp.csproj
+++ b/src/UserApp/UserApp.csproj
@@ -1,14 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFrameworks>netcoreapp2.2;net5.0</TargetFrameworks>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.2' ">
     <PackageReference Include="Baseline" Version="1.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="Baseline" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Upgraded package reference for Oakton.AspNetCore and BaselineTypeDiscovery following their newly added support to Net5.0 

**This is specifically for the Lamar.Diagnostics package** - this should be all that is required in order to make the UseLamar() call work in Net5.0 projectes

Moved the AppVeyor configuration on to use Visual Studio 2019 so that it can use the Net5.0 targeting packs