### PR TITLE
clear scope.disposables collection when disposing container to prevent memory leak

### DIFF
--- a/src/Lamar.Testing/IoC/Acceptance/disposing_container.cs
+++ b/src/Lamar.Testing/IoC/Acceptance/disposing_container.cs
@@ -230,6 +230,23 @@ namespace StructureMap.Testing.Pipeline
             disposableDependent.WasDisposed.ShouldBeTrue();
             disposableDependent.ChildDisposable.WasDisposed.ShouldBeTrue();
         }
+
+        [Theory]
+        [InlineData(DisposalLock.Ignore)]
+        [InlineData(DisposalLock.Unlocked)]
+        public void should_clear_disposables_collection_when_disposed(DisposalLock disposalLock)
+        {
+            var container = new Container(x =>
+            {
+                x.For<Disposable>().Use<Disposable>();
+            });
+
+            var service = container.GetInstance<Disposable>();
+            container.DisposalLock = disposalLock;
+            container.Dispose();
+
+            container.Disposables.ShouldBeEmpty();
+        }
     }
 
     public class DisposableDependent : IDisposable


### PR DESCRIPTION

ConcurrentBag is using thread local variables to store it's content. in some cases when the Bag contains elements
that have circular references (reference an instance of this Bag) the whole graph of objects stay in memory
if the Bag is not cleared before all references are released