### PR TITLE
Added a doc snippet to demonstrate use of Lamar in Blazor

### DIFF
--- a/documentation/documentation/ioc/blazor.md
+++ b/documentation/documentation/ioc/blazor.md
@@ -20,7 +20,7 @@ namespace Lamar.Sample.Blazor
             var builder = WebAssemblyHostBuilder.CreateDefault(args);
             builder.RootComponents.Add<App>("#app");
 
-			// configure Blazor to use Lamar
+            // configure Blazor to use Lamar
             builder.ConfigureContainer<ServiceRegistry>(new LamarServiceProviderFactory(), ConfigureServices);
 
             await builder.Build().RunAsync();
@@ -28,9 +28,9 @@ namespace Lamar.Sample.Blazor
 
         private static void ConfigureServices(ServiceRegistry services)
         {
-			// here you can configure Lamar as normal
-			
-			services.For<IFoo>().Use<Foo>().Singleton();
+            // here you can configure Lamar as normal
+            
+            services.For<IFoo>().Use<Foo>().Singleton();
             services.IncludeRegistry<FooRegistry>();
         }
     }

--- a/documentation/documentation/ioc/blazor.md
+++ b/documentation/documentation/ioc/blazor.md
@@ -1,0 +1,40 @@
+<!--title:Integration with Blazor-->
+
+<[warning]>
+No specific Blazor support has been built into Lamar, and Blazor is still an immature and rapidly-evolving framework. Use of Lamar within Blazor apps is considered experimental.
+<[/warning]>
+
+To use Lamar within Blazor applications, you need only the base [Lamar](https://www.nuget.org/packages/Lamar/) NuGet package installed. Then, you can configure Blazor's host builder to use Lamar for IoC as shown below.
+
+```
+using System.Threading.Tasks;
+using Lamar;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+
+namespace Lamar.Sample.Blazor
+{
+    public class Program
+    {
+        public static async Task Main(string[] args)
+        {
+            var builder = WebAssemblyHostBuilder.CreateDefault(args);
+            builder.RootComponents.Add<App>("#app");
+
+			// configure Blazor to use Lamar
+            builder.ConfigureContainer<ServiceRegistry>(new LamarServiceProviderFactory(), ConfigureServices);
+
+            await builder.Build().RunAsync();
+        }
+
+        private static void ConfigureServices(ServiceRegistry services)
+        {
+			// here you can configure Lamar as normal
+			
+			services.For<IFoo>().Use<Foo>().Singleton();
+            services.IncludeRegistry<FooRegistry>();
+        }
+    }
+}
+```
+
+That's all you need; Blazor will now use Lamar for all dependency injection.

--- a/documentation/documentation/ioc/order.txt
+++ b/documentation/documentation/ioc/order.txt
@@ -1,6 +1,7 @@
 concepts
 bootstrapping
 aspnetcore
+blazor
 registration
 lifetime
 resolving


### PR DESCRIPTION
Nothing fancy, just showing how to hook Lamar into Blazor's startup. I've tested this myself on a small prototype app and found it to work, but my testing has not been exhaustive.

I've deliberately added the code sample inline in the doc file and not used the usual mechanism for extracting code samples from real source code, because that would require a Blazor app in the repo somewhere. Given that no specific Blazor support has been implemented, that seems like a headache you don't need.