### PR TITLE
.NET 6 Support

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,10 +9,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install .NET Core 5.0.x
+      - name: Install .NET Core 6.0.x
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
 
       - name: Install Node.js
         uses: actions/setup-node@v1

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -5,7 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-    
+
 env:
   config: Release
   disable_test_parallelization: true
@@ -22,10 +22,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
     - name: Test
       run: dotnet run -p build/build.csproj -- ci

--- a/.github/workflows/publish_codegen.yml
+++ b/.github/workflows/publish_codegen.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
     - name: Install dependencies
       run: dotnet restore
     - name: Build
@@ -23,7 +23,7 @@ jobs:
       with:
           PROJECT_FILE_PATH: src/LamarCodeGeneration/LamarCodeGeneration.csproj
           NUGET_KEY: ${{secrets.NUGET_API_KEY}}
-          
+
     - name: Publish LamarCodeGeneration.Commands
       uses: brandedoutcast/publish-nuget@v2.5.2
       with:

--- a/.github/workflows/publish_lamar.yml
+++ b/.github/workflows/publish_lamar.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
     - name: Install dependencies
       run: dotnet restore
     - name: Build
@@ -23,7 +23,7 @@ jobs:
       with:
           PROJECT_FILE_PATH: src/Lamar/Lamar.csproj
           NUGET_KEY: ${{secrets.NUGET_API_KEY}}
-          
+
     - name: Publish Lamar.Microsoft.DependencyInjection
       uses: brandedoutcast/publish-nuget@v2.5.2
       with:

--- a/Widget.Core/Widget.Core.csproj
+++ b/Widget.Core/Widget.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Widget.Instance/Widget.Instance.csproj
+++ b/Widget.Instance/Widget.Instance.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Widget.Registration/Widget.Registration.csproj
+++ b/Widget.Registration/Widget.Registration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Aspect.Logger/Widget.Aspect.Logger.csproj
+++ b/src/Aspect.Logger/Widget.Aspect.Logger.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GeneratorTarget/GeneratorTarget.csproj
+++ b/src/GeneratorTarget/GeneratorTarget.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Lamar.AspNetCoreTests.Integration/Lamar.AspNetCoreTests.Integration.csproj
+++ b/src/Lamar.AspNetCoreTests.Integration/Lamar.AspNetCoreTests.Integration.csproj
@@ -34,6 +34,20 @@
     <PackageReference Include="coverlet.collector" Version="1.0.1" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="[6.0.0,6.9.0)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[6.0.0,6.9.0)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[6.0.0,6.9.0)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="[6.0.0,6.9.0)" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[6.0.0,6.9.0)" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="[6.0.0,6.9.0)" />
+    <PackageReference Include="Shouldly" Version="3.0.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Lamar.Microsoft.DependencyInjection\Lamar.Microsoft.DependencyInjection.csproj" />
     <ProjectReference Include="..\LamarCompiler\LamarCompiler.csproj" />

--- a/src/Lamar.AspNetCoreTests/Lamar.AspNetCoreTests.csproj
+++ b/src/Lamar.AspNetCoreTests/Lamar.AspNetCoreTests.csproj
@@ -33,12 +33,18 @@
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-    <PackageReference Include="AspNetCore.HealthChecks.UI" Version="5.0.0-preview1" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI" Version="5.0.1" />
     <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.HealthChecks" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
   </ItemGroup>
-  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="AspNetCore.HealthChecks.UI" Version="5.0.1" />
+    <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.HealthChecks" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
+  </ItemGroup>
+
   <ItemGroup>
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Lamar.Diagnostics/Lamar.Diagnostics.csproj
+++ b/src/Lamar.Diagnostics/Lamar.Diagnostics.csproj
@@ -2,9 +2,9 @@
 
     <PropertyGroup>
         <Description>Adds diagnostic checks to the command line of your Lamar-enabled ASP.Net Core app</Description>
-        <Version>6.0.0</Version>
+        <Version>6.0.1</Version>
         <Authors>Jeremy D. Miller</Authors>
-        <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
         <DebugType>portable</DebugType>
         <AssemblyName>Lamar.Diagnostics</AssemblyName>
         <PackageId>Lamar.Diagnostics</PackageId>
@@ -17,7 +17,7 @@
         <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
         <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
     </PropertyGroup>
-    
+
     <ItemGroup>
         <ProjectReference Include="..\Lamar\Lamar.csproj" />
         <PackageReference Include="BaselineTypeDiscovery" Version="1.1.1" />

--- a/src/Lamar.Microsoft.DependencyInjection/Lamar.Microsoft.DependencyInjection.csproj
+++ b/src/Lamar.Microsoft.DependencyInjection/Lamar.Microsoft.DependencyInjection.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Lamar Adapter for ASP.Net Core</Description>
-    <Version>6.0.0</Version>
+    <Version>6.0.1</Version>
     <Authors>Jeremy D. Miller</Authors>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>Lamar.Microsoft.DependencyInjection</AssemblyName>
     <PackageId>Lamar.Microsoft.DependencyInjection</PackageId>
@@ -33,5 +33,12 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="[5.0.0,7.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="[5.0.0,7.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="[5.0.0,7.0.0)" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.2.0, 3.0)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[6.0.0,8.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="[6.0.0,8.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="[6.0.0,8.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="[6.0.0,8.0.0)" />
   </ItemGroup>
 </Project>

--- a/src/Lamar.Testing/Lamar.Testing.csproj
+++ b/src/Lamar.Testing/Lamar.Testing.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Baseline" Version="2.1.1" />
@@ -32,7 +32,11 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
   </ItemGroup>
-  
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+  </ItemGroup>
+
   <ItemGroup>
     <Compile Remove="Codegen\StubGeneratedMethod.cs" />
   </ItemGroup>

--- a/src/Lamar/Lamar.csproj
+++ b/src/Lamar/Lamar.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Fast ASP.Net Core compatible IoC Tool, Successor to StructureMap</Description>
-    <Version>6.0.0</Version>
+    <Version>6.0.1</Version>
     <Authors>Jeremy D. Miller</Authors>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>Lamar</AssemblyName>
     <PackageId>Lamar</PackageId>
@@ -33,5 +33,11 @@
     <PackageReference Include="BaselineTypeDiscovery" Version="1.1.1" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5.0.0, 5.9.0)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="BaselineTypeDiscovery" Version="1.1.1" />
+    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[6.0.0, 6.9.0)" />
   </ItemGroup>
 </Project>

--- a/src/LamarCodeGeneration.Commands/LamarCodeGeneration.Commands.csproj
+++ b/src/LamarCodeGeneration.Commands/LamarCodeGeneration.Commands.csproj
@@ -4,7 +4,7 @@
         <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
 
         <Description>Command line utilities for managing Lamar dynamically generated code</Description>
-        <Version>2.0.3</Version>
+        <Version>2.0.4</Version>
         <Authors>Jeremy D. Miller</Authors>
         <DebugType>portable</DebugType>
         <AssemblyName>LamarCodeGeneration.Commands</AssemblyName>

--- a/src/LamarCodeGeneration.Commands/LamarCodeGeneration.Commands.csproj
+++ b/src/LamarCodeGeneration.Commands/LamarCodeGeneration.Commands.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
 
         <Description>Command line utilities for managing Lamar dynamically generated code</Description>
         <Version>2.0.3</Version>
@@ -27,6 +27,6 @@
     <ItemGroup>
         <PackageReference Include="Oakton" Version="[3.0.0, 4.0.0)" />
     </ItemGroup>
-    
+
 
 </Project>

--- a/src/LamarCodeGeneration/LamarCodeGeneration.csproj
+++ b/src/LamarCodeGeneration/LamarCodeGeneration.csproj
@@ -4,7 +4,7 @@
         <Description>Code Generation Chicanery for .Net</Description>
         <Version>3.2.2</Version>
         <Authors>Jeremy D. Miller</Authors>
-        <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
         <DebugType>portable</DebugType>
         <AssemblyName>LamarCodeGeneration</AssemblyName>
         <PackageId>LamarCodeGeneration</PackageId>
@@ -17,7 +17,7 @@
         <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
         <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
     </PropertyGroup>
-    
+
     <ItemGroup>
       <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
       <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />

--- a/src/LamarCodeGeneration/LamarCodeGeneration.csproj
+++ b/src/LamarCodeGeneration/LamarCodeGeneration.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <Description>Code Generation Chicanery for .Net</Description>
-        <Version>3.2.2</Version>
+        <Version>3.2.3</Version>
         <Authors>Jeremy D. Miller</Authors>
         <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
         <DebugType>portable</DebugType>

--- a/src/LamarCompiler.Testing/LamarCompiler.Testing.csproj
+++ b/src/LamarCompiler.Testing/LamarCompiler.Testing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -18,7 +18,11 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
     <PackageReference Include="Baseline" Version="2.1.1" />
   </ItemGroup>
-  
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="Baseline" Version="2.1.1" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\LamarCompiler\LamarCompiler.csproj" />
     <ProjectReference Include="..\Lamar\Lamar.csproj" />

--- a/src/LamarCompiler/LamarCompiler.csproj
+++ b/src/LamarCompiler/LamarCompiler.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Runtime Roslyn Compilation and Code Generation Chicanery</Description>
-    <Version>3.0.4</Version>
+    <Version>3.0.5</Version>
     <Authors>Jeremy D. Miller</Authors>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <DebugType>portable</DebugType>

--- a/src/LamarCompiler/LamarCompiler.csproj
+++ b/src/LamarCompiler/LamarCompiler.csproj
@@ -3,7 +3,7 @@
     <Description>Runtime Roslyn Compilation and Code Generation Chicanery</Description>
     <Version>3.0.4</Version>
     <Authors>Jeremy D. Miller</Authors>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>LamarCompiler</AssemblyName>
     <PackageId>LamarCompiler</PackageId>
@@ -21,11 +21,15 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="3.11.0" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' "> 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
   </ItemGroup>

--- a/src/LamarDiagnosticsWithNetCore3Demonstrator/LamarDiagnosticsWithNetCore3Demonstrator.csproj
+++ b/src/LamarDiagnosticsWithNetCore3Demonstrator/LamarDiagnosticsWithNetCore3Demonstrator.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
@@ -21,6 +21,10 @@
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/LamarDiagnosticsWithNetCore3Demonstrator/Program.cs
+++ b/src/LamarDiagnosticsWithNetCore3Demonstrator/Program.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Lamar;
 using Lamar.Diagnostics;
 using Lamar.Microsoft.DependencyInjection;
@@ -22,15 +19,15 @@ namespace LamarDiagnosticsWithNetCore3Demonstrator
             return new HostBuilder()
                 .UseLamar((context, services) =>
                 {
-// This adds a Container validation
-// to the Oakton "check-env" command
-services.CheckLamarConfiguration();
-                    
-                    // And the rest of your application's 
+                    // This adds a Container validation
+                    // to the Oakton "check-env" command
+                    services.CheckLamarConfiguration();
+
+                    // And the rest of your application's
                     // DI registrations.
                     services.IncludeRegistry<TestClassRegistry>();
                 })
-                
+
                 // Call this method to start your application
                 // with Oakton handling the command line parsing
                 // and delegation
@@ -48,7 +45,7 @@ services.CheckLamarConfiguration();
                 s.TheCallingAssembly();
                 s.WithDefaultConventions();
             });
-                    
+
             For<IEngine>().Use<Hemi>().Named("The Hemi");
 
             For<IEngine>().Add<VEight>().Singleton().Named("V8");
@@ -67,11 +64,11 @@ services.CheckLamarConfiguration();
             ForConcreteType<DeepConstructorGuy>();
 
             For<EngineChoice>().Add<EngineChoice>();
-                    
+
             For<IService>().Use(new ColorService("red"));
 
             Policies.SetAllProperties(policy => { policy.TypeMatches(type => type == typeof(IService)); });
-                    
+
             For<IGateway>().Use<DefaultGateway>()
                 .Setter<string>("Name").Is("Blue")
                 .Setter<string>("Color").Is("Green");

--- a/src/LamarWithAspNetCore3/LamarWithAspNetCore3.csproj
+++ b/src/LamarWithAspNetCore3/LamarWithAspNetCore3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>
@@ -20,14 +20,18 @@
       <ProjectReference Include="..\StructureMap.Testing.Widget\StructureMap.Testing.Widget.csproj" />
     </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="Baseline" Version="1.5.0" />
-  </ItemGroup>
+    </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
       <PackageReference Include="Baseline" Version="2.1.1" />
     </ItemGroup>
-  
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+      <PackageReference Include="Baseline" Version="2.1.1" />
+    </ItemGroup>
+
     <ItemGroup>
         <None Update="appsettings.json">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/LamarWithAspNetCoreMvc3/LamarWithAspNetCoreMvc3.csproj
+++ b/src/LamarWithAspNetCoreMvc3/LamarWithAspNetCoreMvc3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     </PropertyGroup>
 
 

--- a/src/StructureMap.Testing.GenericWidgets/StructureMap.Testing.GenericWidgets.csproj
+++ b/src/StructureMap.Testing.GenericWidgets/StructureMap.Testing.GenericWidgets.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <AssemblyName>StructureMap.Testing.GenericWidgets</AssemblyName>
     <PackageId>StructureMap.Testing.GenericWidgets</PackageId>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/src/StructureMap.Testing.Widget/StructureMap.Testing.Widget.csproj
+++ b/src/StructureMap.Testing.Widget/StructureMap.Testing.Widget.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <AssemblyName>StructureMap.Testing.Widget</AssemblyName>
     <PackageId>StructureMap.Testing.Widget</PackageId>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/src/StructureMap.Testing.Widget2/StructureMap.Testing.Widget2.csproj
+++ b/src/StructureMap.Testing.Widget2/StructureMap.Testing.Widget2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <AssemblyName>StructureMap.Testing.Widget2</AssemblyName>
     <PackageId>StructureMap.Testing.Widget2</PackageId>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/src/StructureMap.Testing.Widget3/StructureMap.Testing.Widget3.csproj
+++ b/src/StructureMap.Testing.Widget3/StructureMap.Testing.Widget3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <AssemblyName>StructureMap.Testing.Widget3</AssemblyName>
     <PackageId>StructureMap.Testing.Widget3</PackageId>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
@@ -11,5 +11,5 @@
     <ProjectReference Include="..\Lamar\Lamar.csproj" />
     <ProjectReference Include="..\StructureMap.Testing.Widget\StructureMap.Testing.Widget.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/StructureMap.Testing.Widget4/StructureMap.Testing.Widget4.csproj
+++ b/src/StructureMap.Testing.Widget4/StructureMap.Testing.Widget4.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <AssemblyName>StructureMap.Testing.Widget4</AssemblyName>
     <PackageId>StructureMap.Testing.Widget4</PackageId>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.5' ">1.6.0</NetStandardImplicitPackageVersion>

--- a/src/StructureMap.Testing.Widget5/StructureMap.Testing.Widget5.csproj
+++ b/src/StructureMap.Testing.Widget5/StructureMap.Testing.Widget5.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <AssemblyName>StructureMap.Testing.Widget5</AssemblyName>
     <PackageId>StructureMap.Testing.Widget5</PackageId>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/src/UserApp/UserApp.csproj
+++ b/src/UserApp/UserApp.csproj
@@ -16,4 +16,10 @@
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
   </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="Baseline" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Hi there!

As other people have mentioned already, .NET 6.0 is officially out and it would be great if Lamar was setup to support it. The work isn't a big deal as it requires to replicate a few nugets configuration within the csprojs and making sure all tests pass.

I haven't touched the test targets so they are running under net5.0 still, not sure if we want to change these too.

Github actions have been updated as well to use .NET 6 instead of .NET 5.

See #298