### PR TITLE
Fixed Broken Paths in csproj Files

### DIFF
--- a/src/Aspect.Logger/Widget.Aspect.Logger.csproj
+++ b/src/Aspect.Logger/Widget.Aspect.Logger.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Widget.Core\Widget.Core.csproj" />
     <ProjectReference Include="..\Lamar\Lamar.csproj" />
     <ProjectReference Include="..\Widget.Core\Widget.Core.csproj" />
   </ItemGroup>

--- a/src/Lamar.Testing/Lamar.Testing.csproj
+++ b/src/Lamar.Testing/Lamar.Testing.csproj
@@ -10,9 +10,6 @@
     <PackageReference Include="NSubstitute" Version="3.1.0" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\Widget.Core\Widget.Core.csproj" />
-    <ProjectReference Include="..\..\Widget.Instance\Widget.Instance.csproj" />
-    <ProjectReference Include="..\..\Widget.Registration\Widget.Registration.csproj" />
     <ProjectReference Include="..\Aspect.Logger\Widget.Aspect.Logger.csproj" />
     <ProjectReference Include="..\Lamar.Diagnostics\Lamar.Diagnostics.csproj" />
     <ProjectReference Include="..\Lamar\Lamar.csproj" />

--- a/src/Widget.Core/Widget.Core.csproj
+++ b/src/Widget.Core/Widget.Core.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\src\Lamar\Lamar.csproj" />
+    <ProjectReference Include="..\Lamar\Lamar.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Widget.Instance/Widget.Instance.csproj
+++ b/src/Widget.Instance/Widget.Instance.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\src\Lamar\Lamar.csproj" />
+    <ProjectReference Include="..\Lamar\Lamar.csproj" />
     <ProjectReference Include="..\Widget.Core\Widget.Core.csproj" />
   </ItemGroup>
 

--- a/src/Widget.Registration/Widget.Registration.csproj
+++ b/src/Widget.Registration/Widget.Registration.csproj
@@ -7,8 +7,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Aspect.Logger\Widget.Aspect.Logger.csproj" />
     <ProjectReference Include="..\Lamar\Lamar.csproj" />
-    <ProjectReference Include="..\src\Aspect.Logger\Widget.Aspect.Logger.csproj" />
-    <ProjectReference Include="..\src\Lamar\Lamar.csproj" />
     <ProjectReference Include="..\Widget.Core\Widget.Core.csproj" />
     <ProjectReference Include="..\Widget.Instance\Widget.Instance.csproj" />
   </ItemGroup>


### PR DESCRIPTION
When I do a fresh clone of the Lamar repository and try to compile the solution, I get several compile errors about projects not being found. Those are due to bad or duplicate project paths in some of the `.csproj` files. The fixes in this PR clean those up.

Everything compiles now and all tests pass.