### PR TITLE
Fix support for named parameters with constructor injection

### DIFF
--- a/src/Lamar.Testing/IoC/NamedAttributeOnParameterTest.cs
+++ b/src/Lamar.Testing/IoC/NamedAttributeOnParameterTest.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Shouldly;
+using StructureMap.Testing.Widget;
+using Xunit;
+
+namespace Lamar.Testing.IoC
+{
+    public class NamedAttributeOnParameterTest
+    {
+        class GreenWidget : IWidget
+        {
+            public void DoSomething()
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        class BlueWidget : IWidget
+        {
+            public void DoSomething()
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        class NamedParameterWidgetUser
+        {
+            public IWidget Widget { get; }
+
+            public NamedParameterWidgetUser([Named("green")]IWidget widget)
+            {
+                Widget = widget;
+            }
+        }
+        
+        [Fact]
+        public void honor_named_attribute_on_parameter()
+        {
+            var container = new Container(_ =>
+            {
+                _.For<IWidget>().Use<GreenWidget>().Named("green");
+                _.For<IWidget>().Use<BlueWidget>().Named("blue");
+            });
+
+            container.GetInstance<IWidget>().ShouldBeOfType<BlueWidget>();
+
+            container.GetInstance<NamedParameterWidgetUser>().Widget.ShouldBeOfType<GreenWidget>();
+        }
+    }
+}

--- a/src/Lamar/IoC/Instances/ConstructorInstance.cs
+++ b/src/Lamar/IoC/Instances/ConstructorInstance.cs
@@ -388,13 +388,13 @@ namespace Lamar.IoC.Instances
             {
                 if (parameter.DefaultValue == null)
                 {
-                    return services.FindDefault(dependencyType) ?? new NullInstance(dependencyType);
+                    return services.FindInstance(parameter) ?? new NullInstance(dependencyType);
                 }
 
                 return new ObjectInstance(parameter.ParameterType, parameter.DefaultValue);
             }
 
-            return services.FindDefault(dependencyType);
+            return services.FindInstance(parameter);
 
         }
 


### PR DESCRIPTION
Currently named parameters only affect QuickBuild, but this PR should fix it when using GetInstance or auto-injection into constructors.