### PR TITLE
Add IServiceProviderIsService to ServiceRegistry

### DIFF
--- a/src/Lamar.Microsoft.DependencyInjection/LamarServiceProviderFactory.cs
+++ b/src/Lamar.Microsoft.DependencyInjection/LamarServiceProviderFactory.cs
@@ -8,6 +8,7 @@ namespace Lamar.Microsoft.DependencyInjection
         public ServiceRegistry CreateBuilder(IServiceCollection services)
         {
             var registry = new ServiceRegistry();
+            services.AddSingleton<IServiceProviderIsService>(s => (IServiceProviderIsService)s.GetRequiredService<IContainer>());
             registry.AddRange(services);
 
             return registry;


### PR DESCRIPTION
@maryamariyan was showing me this code because it looks like `IServiceProviderIsService` isn't being properly registered in the ServiceRegistry. I'm not sure this works, but it should be closer to working. I copied `(IServiceProviderIsService)s.GetRequiredService<IContainer>()` from https://github.com/JasperFx/lamar/blob/v8.0.1/src/Lamar.Microsoft.DependencyInjection/HostBuilderExtensions.cs#L90 but it doesn't look like `IContainer` implements `IServiceProviderIsService`.

We'll want to add tests, ifdef, and remove the dead code before merging this though.