### PR TITLE
Support .NET7

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -26,6 +26,10 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
+        dotnet-version: 7.0.x
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
         dotnet-version: 6.0.x
     - name: Setup .NET 5
       uses: actions/setup-dotnet@v1

--- a/src/Lamar.AspNetCoreTests.Integration/Lamar.AspNetCoreTests.Integration.csproj
+++ b/src/Lamar.AspNetCoreTests.Integration/Lamar.AspNetCoreTests.Integration.csproj
@@ -1,37 +1,44 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="[5.0.0,5.9.0)" />
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[5.0.0,5.9.0)" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[5.0.0,5.9.0)" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="[5.0.0,5.9.0)" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[5.0.0,5.9.0)" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="[5.0.0,5.9.0)" />
     <PackageReference Include="Shouldly" Version="3.0.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.0.1" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="[5.0.0,6.0.0)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[5.0.0,6.0.0)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[5.0.0,6.0.0)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="[5.0.0,6.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[5.0.0,6.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="[5.0.0,6.0.0)" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="[6.0.0,6.9.0)" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[6.0.0,6.9.0)" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[6.0.0,6.9.0)" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="[6.0.0,6.9.0)" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[6.0.0,6.9.0)" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="[6.0.0,6.9.0)" />
-    <PackageReference Include="Shouldly" Version="3.0.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="[6.0.0,7.0.0)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[6.0.0,7.0.0)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[6.0.0,7.0.0)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="[6.0.0,7.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[6.0.0,7.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="[6.0.0,7.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="[7.0.0,8.0.0)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[7.0.0,8.0.0)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[7.0.0,8.0.0)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="[7.0.0,8.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[7.0.0,8.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="[7.0.0,8.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Lamar.AspNetCoreTests/Lamar.AspNetCoreTests.csproj
+++ b/src/Lamar.AspNetCoreTests/Lamar.AspNetCoreTests.csproj
@@ -1,13 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
 
     <PackageReference Include="App.Metrics.AspNetCore.Mvc" Version="4.2.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI" Version="5.0.1" />
 
     <PackageReference Include="IdentityServer4" Version="4.1.2" />
+    <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
 
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.7" />
@@ -24,18 +26,16 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-    <PackageReference Include="AspNetCore.HealthChecks.UI" Version="5.0.1" />
-    <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.HealthChecks" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
     <PackageReference Include="Baseline" Version="3.2.2" />
+    <PackageReference Include=" Microsoft.Extensions.Diagnostics.HealthChecks" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="AspNetCore.HealthChecks.UI" Version="5.0.1" />
-    <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.HealthChecks" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
     <PackageReference Include="Alba" Version="6.0.0" />
+    <PackageReference Include=" Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+    <PackageReference Include="Alba" Version="6.0.0" />
+    <PackageReference Include=" Microsoft.Extensions.Diagnostics.HealthChecks" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Lamar.Testing/Lamar.Testing.csproj
+++ b/src/Lamar.Testing/Lamar.Testing.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
@@ -23,14 +24,6 @@
     <ProjectReference Include="..\Widget.Core\Widget.Core.csproj" />
     <ProjectReference Include="..\Widget.Instance\Widget.Instance.csproj" />
     <ProjectReference Include="..\Widget.Registration\Widget.Registration.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Lamar/Lamar.csproj
+++ b/src/Lamar/Lamar.csproj
@@ -37,6 +37,6 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[6.0.0, 7.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[6.0.0, 8.0.0)" />
   </ItemGroup>
 </Project>

--- a/src/LamarCompiler.Testing/LamarCompiler.Testing.csproj
+++ b/src/LamarCompiler.Testing/LamarCompiler.Testing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -12,14 +12,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
-    <PackageReference Include="Baseline" Version="2.1.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-    <PackageReference Include="Baseline" Version="2.1.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <PackageReference Include="Baseline" Version="2.1.1" />
   </ItemGroup>
 

--- a/src/LamarWithAspNetCore3/LamarWithAspNetCore3.csproj
+++ b/src/LamarWithAspNetCore3/LamarWithAspNetCore3.csproj
@@ -1,12 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Baseline" Version="2.1.1" />
       <FrameworkReference Include="Microsoft.AspNetCore.App" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
       <PackageReference Include="xunit" Version="2.4.0" />
@@ -18,14 +19,6 @@
     <ItemGroup>
       <ProjectReference Include="..\Lamar.Microsoft.DependencyInjection\Lamar.Microsoft.DependencyInjection.csproj" />
       <ProjectReference Include="..\StructureMap.Testing.Widget\StructureMap.Testing.Widget.csproj" />
-    </ItemGroup>
-
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-      <PackageReference Include="Baseline" Version="2.1.1" />
-    </ItemGroup>
-
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-      <PackageReference Include="Baseline" Version="2.1.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/MinimalApiTests/MinimalApiTests.csproj
+++ b/src/MinimalApiTests/MinimalApiTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>


### PR DESCRIPTION
Closes #360 

* Updated test projects target framework to include .NET7
* Updated Lamar dependency version range

Do we also want the main lib to target .NET7? As far as I'm aware, it's only needed if we want to use new APIs or language features

Also as mentioned in issue, do we drop support for .NET5