### PR TITLE
Don't resolve collections for not registered types when IServiceProviderIsService is used - GH-391

### DIFF
--- a/src/Lamar.Testing/IoC/Acceptance/IServiceProviderIsService_implementation.cs
+++ b/src/Lamar.Testing/IoC/Acceptance/IServiceProviderIsService_implementation.cs
@@ -37,6 +37,27 @@ public class IServiceProviderIsService_implementation
         container.IsService(typeof(IGenericService1<ConcreteClass>)).ShouldBeTrue();
     }
 
+    [Fact]
+    public void fix_for_391_dont_resolve_collections_with_not_registered_type()
+    {
+        var containerWithNoRegistrations = Container.Empty();
+
+        containerWithNoRegistrations.IsService(typeof(IEnumerable<ConcreteClass>)).ShouldBeFalse();
+        containerWithNoRegistrations.IsService(typeof(IReadOnlyCollection<ConcreteClass>)).ShouldBeFalse();
+        containerWithNoRegistrations.IsService(typeof(IList<ConcreteClass>)).ShouldBeFalse();
+        containerWithNoRegistrations.IsService(typeof(List<ConcreteClass>)).ShouldBeFalse();
+
+        var containerWithRegistrations = Container.For(services =>
+                                                      {
+                                                          services.ForConcreteType<ConcreteClass>();
+                                                      });
+
+        containerWithRegistrations.IsService(typeof(IEnumerable<ConcreteClass>)).ShouldBeTrue();
+        containerWithRegistrations.IsService(typeof(IReadOnlyCollection<ConcreteClass>)).ShouldBeTrue();
+        containerWithRegistrations.IsService(typeof(IList<ConcreteClass>)).ShouldBeTrue();
+        containerWithRegistrations.IsService(typeof(List<ConcreteClass>)).ShouldBeTrue();
+    }
+
     public interface IService
     {
     }


### PR DESCRIPTION
At the moment Lamar is used to resolve collection types in methods of web api controllers, therefore the collections are always empty (no matter which values are available in the body of the request).

With this change Lamar will not be used to resolve collection types when the type (e.g IReadOnlyCollection<UpdateCommand> --> UpdateCommand) is not explicitly registered, therefore the asp.net core model builder kicks in and the creates the collection (as expected).

This PR closes #391.