### PR TITLE
Add support for `IServiceProviderIsKeyedService` in Lamar DI framework

### DIFF
--- a/src/Lamar.Microsoft.DependencyInjection/HostBuilderExtensions.cs
+++ b/src/Lamar.Microsoft.DependencyInjection/HostBuilderExtensions.cs
@@ -39,7 +39,8 @@ namespace Lamar.Microsoft.DependencyInjection
             
             // This enables the usage of implicit services in Minimal APIs
             builder.Services.AddSingleton(s => (IServiceProviderIsService) s.GetRequiredService<IContainer>());
-            
+            builder.Services.AddSingleton(s => (IServiceProviderIsKeyedService) s.GetRequiredService<IContainer>());
+
             builder.ConfigureContainer<ServiceRegistry>(new LamarServiceProviderFactory(), x =>
             {
                 configure?.Invoke(x);
@@ -76,8 +77,9 @@ namespace Lamar.Microsoft.DependencyInjection
 #if NET6_0_OR_GREATER
                     // This enables the usage of implicit services in Minimal APIs
                     services.AddSingleton(s => (IServiceProviderIsService) s.GetRequiredService<IContainer>());
+                    services.AddSingleton(s => (IServiceProviderIsKeyedService) s.GetRequiredService<IContainer>());
 #endif
-                    
+
                 });
         }
         
@@ -119,6 +121,7 @@ namespace Lamar.Microsoft.DependencyInjection
 
 #if NET6_0_OR_GREATER
             services.AddSingleton<IServiceProviderIsService>(s => (IServiceProviderIsService) s.GetRequiredService<IContainer>());
+            services.AddSingleton<IServiceProviderIsKeyedService>(s => (IServiceProviderIsKeyedService)s.GetRequiredService<IContainer>());
 #endif
 
             registry ??= new ServiceRegistry();

--- a/src/Lamar.Testing/IoC/Acceptance/IServiceProviderIsKeyedService_implementation.cs
+++ b/src/Lamar.Testing/IoC/Acceptance/IServiceProviderIsKeyedService_implementation.cs
@@ -1,0 +1,94 @@
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using StructureMap.Testing.Widget;
+using Xunit;
+
+namespace Lamar.Testing.IoC.Acceptance;
+#if NET6_0_OR_GREATER
+public class IServiceProviderIsKeyedService_implementation
+{
+    [Fact]
+    public void explicit_checks_of_non_concrete_types()
+    {
+        var container = Container.For(services => { 
+            services.For<IClock>().Use<Clock>();
+            services.AddKeyedSingleton<IClock, Clock>("IClock");
+        });
+        
+        container.IsKeyedService(typeof(IClock), "IClock").ShouldBeTrue();
+        container.IsKeyedService(typeof(IWidget), "IWidget").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void fix_for_368_auto_resolve_enumerable_concretes_and_generics()
+    {
+        var container = Container.For(services =>
+        {
+            services.Scan(s =>
+            {
+                s.AssemblyContainingType(GetType());
+                s.WithDefaultConventions();
+                s.AddAllTypesOf<IService>();
+            });
+
+            services.For(typeof(IGenericService1<>)).Use(typeof(GenericService1<>));
+            services.AddKeyedSingleton<IEnumerable<IService>, List<ServiceA>>("IEnumerable<ServiceA>");
+            services.AddKeyedSingleton<IEnumerable<IService>, List<ServiceB>>("IEnumerable<ServiceB>");
+            services.AddKeyedSingleton(typeof(IGenericService1<>), "GenericService1<>", typeof(GenericService1<>));
+
+        });
+
+        container.IsKeyedService(typeof(ConcreteClass), "ConcreteClass").ShouldBeFalse();
+        container.IsKeyedService(typeof(IEnumerable<IService>), "IEnumerable<ServiceA>").ShouldBeTrue();
+        container.IsKeyedService(typeof(IGenericService1<IService>), "IGenericService1<IService>").ShouldBeTrue();
+        container.IsKeyedService(typeof(IGenericService1<ConcreteClass>), "IGenericService1<ConcreteClass>").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void fix_for_391_dont_resolve_collections_with_not_registered_type()
+    {
+        var containerWithNoRegistrations = Container.Empty();
+
+        containerWithNoRegistrations.IsKeyedService(typeof(IEnumerable<ConcreteClass>),"IEnumerable<ConcreteClass>").ShouldBeFalse();
+        containerWithNoRegistrations.IsKeyedService(typeof(IReadOnlyCollection<ConcreteClass>) ,"IReadOnlyCollection<ConcreteClass>").ShouldBeFalse();
+        containerWithNoRegistrations.IsKeyedService(typeof(IList<ConcreteClass>), "IList<ConcreteClass>").ShouldBeFalse();
+        containerWithNoRegistrations.IsKeyedService(typeof(List<ConcreteClass>), "List<ConcreteClass>").ShouldBeFalse();
+
+        var containerWithRegistrations = Container.For(services =>
+                                                      {
+                                                          services.ForConcreteType<ConcreteClass>();
+                                                          services.AddKeyedSingleton<IEnumerable<IService>, List<ServiceA>>("IEnumerable<ServiceA>");
+                                                      });
+
+        containerWithRegistrations.IsKeyedService(typeof(IEnumerable<ConcreteClass>), "IEnumerable<ConcreteClass>").ShouldBeTrue();
+        containerWithRegistrations.IsKeyedService(typeof(IReadOnlyCollection<ConcreteClass>), "IReadOnlyCollection<ConcreteClass>").ShouldBeTrue();
+        containerWithRegistrations.IsKeyedService(typeof(IList<ConcreteClass>), "IList<ConcreteClass>").ShouldBeTrue();
+        containerWithRegistrations.IsKeyedService(typeof(List<ConcreteClass>), "List<ConcreteClass>").ShouldBeTrue();
+    }
+
+    public interface IService
+    {
+    }
+
+    public class ServiceA : IService
+    {
+    }
+
+    public class ServiceB : IService
+    {
+    }
+
+    public class ConcreteClass
+    {
+    }
+
+    public interface IGenericService1<T>
+    {
+    }
+
+    public class GenericService1<T> : IGenericService1<T>
+    {
+    }
+}
+#endif

--- a/src/Lamar/IoC/Scope.cs
+++ b/src/Lamar/IoC/Scope.cs
@@ -21,7 +21,7 @@ namespace Lamar.IoC;
 
 #region sample_Scope-Declarations
 
-public class Scope : IServiceContext, IServiceProviderIsService
+public class Scope : IServiceContext, IServiceProviderIsService, IServiceProviderIsKeyedService
 
     #endregion
 
@@ -369,6 +369,11 @@ public class Scope : IServiceContext, IServiceProviderIsService
     public bool IsService(Type serviceType)
     {
         return ServiceGraph.CanBeServiceByNetCoreRules(serviceType);
+    }
+
+    public bool IsKeyedService(Type serviceType, object serviceKey)
+    {
+        return ServiceGraph.CanBeServiceByNetCoreRules(serviceType, serviceKey.ToString());
     }
 
     public static Scope Empty()

--- a/src/Lamar/ServiceGraph.cs
+++ b/src/Lamar/ServiceGraph.cs
@@ -622,6 +622,6 @@ public class ServiceGraph : IDisposable, IAsyncDisposable
             }
         }
 
-        return family.Default != null;
+        return  family.InstanceFor(name) != null;
     }
 }


### PR DESCRIPTION
Implement `IServiceProviderIsKeyedService` in `Scope.cs` with `IsKeyedService`.

Update `ServiceGraph` class with `CanBeServiceByNetCoreRules` method to support keyed service searching.