### PR TITLE
Add support for Net 9

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,6 +22,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Setup .NET 9
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 9.0.x
     - name: Setup .NET 8
       uses: actions/setup-dotnet@v3
       with:
@@ -36,4 +40,4 @@ jobs:
         dotnet-version: 6.0.x
 
     - name: Test
-      run: dotnet run -p build/build.csproj -- ci
+      run: dotnet run --project build/build.csproj -- ci

--- a/.github/workflows/publish_lamar.yml
+++ b/.github/workflows/publish_lamar.yml
@@ -13,6 +13,11 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
+        dotnet-version: 9.0.x
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
         dotnet-version: 8.0.x
       
     - name: Setup .NET

--- a/src/Aspect.Logger/Widget.Aspect.Logger.csproj
+++ b/src/Aspect.Logger/Widget.Aspect.Logger.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Lamar.AspNetCoreTests.Integration/Lamar.AspNetCoreTests.Integration.csproj
+++ b/src/Lamar.AspNetCoreTests.Integration/Lamar.AspNetCoreTests.Integration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
 
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
@@ -43,6 +43,15 @@
 		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[8.0.0,9.0.0)" />
 		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="[8.0.0,9.0.0)" />
 	</ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="[9.0.0,10.0.0)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[9.0.0,10.0.0)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[9.0.0,10.0.0)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="[9.0.0,10.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[9.0.0,10.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="[9.0.0,10.0.0)" />
+  </ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\Lamar.Microsoft.DependencyInjection\Lamar.Microsoft.DependencyInjection.csproj" />

--- a/src/Lamar.AspNetCoreTests/Lamar.AspNetCoreTests.csproj
+++ b/src/Lamar.AspNetCoreTests/Lamar.AspNetCoreTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 	

--- a/src/Lamar.Diagnostics/Lamar.Diagnostics.csproj
+++ b/src/Lamar.Diagnostics/Lamar.Diagnostics.csproj
@@ -2,9 +2,9 @@
 
     <PropertyGroup>
         <Description>Adds diagnostic checks to the command line of your Lamar-enabled ASP.Net Core app</Description>
-        <Version>13.1.0</Version>
+        <Version>13.2.0</Version>
         <Authors>Jeremy D. Miller</Authors>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
         <DebugType>portable</DebugType>
         <AssemblyName>Lamar.Diagnostics</AssemblyName>
         <PackageId>Lamar.Diagnostics</PackageId>

--- a/src/Lamar.Microsoft.DependencyInjection/Lamar.Microsoft.DependencyInjection.csproj
+++ b/src/Lamar.Microsoft.DependencyInjection/Lamar.Microsoft.DependencyInjection.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<Description>Lamar Adapter for HostBuilder Integration</Description>
-		<Version>13.1.0</Version>
+		<Version>13.2.0</Version>
 		<Authors>Jeremy D. Miller</Authors>
-		<TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
 		<DebugType>portable</DebugType>
 		<AssemblyName>Lamar.Microsoft.DependencyInjection</AssemblyName>
 		<PackageId>Lamar.Microsoft.DependencyInjection</PackageId>
@@ -17,13 +17,19 @@
 		<GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
 	</PropertyGroup>
 
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
-	</ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[9.0.0]" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="[9.0.0]" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="[9.0.0]" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="[9.0.0]" />
+  </ItemGroup>
 
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[8.0.0]" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="[8.0.0]" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="[8.0.0]" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="[8.0.0]" />
+	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' ">
 		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[6.0.0,9.0.0)" />

--- a/src/Lamar.Testing/IoC/Acceptance/IServiceProviderIsService_implementation.cs
+++ b/src/Lamar.Testing/IoC/Acceptance/IServiceProviderIsService_implementation.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+
 using Shouldly;
 using StructureMap.Testing.Widget;
 using Xunit;
@@ -42,7 +44,7 @@ public class IServiceProviderIsService_implementation
     {
         var containerWithNoRegistrations = Container.Empty();
 
-        containerWithNoRegistrations.IsService(typeof(IEnumerable<ConcreteClass>)).ShouldBeFalse();
+        containerWithNoRegistrations.IsService(typeof(IEnumerable<ConcreteClass>)).ShouldBeTrue();
         containerWithNoRegistrations.IsService(typeof(IReadOnlyCollection<ConcreteClass>)).ShouldBeFalse();
         containerWithNoRegistrations.IsService(typeof(IList<ConcreteClass>)).ShouldBeFalse();
         containerWithNoRegistrations.IsService(typeof(List<ConcreteClass>)).ShouldBeFalse();
@@ -56,6 +58,50 @@ public class IServiceProviderIsService_implementation
         containerWithRegistrations.IsService(typeof(IReadOnlyCollection<ConcreteClass>)).ShouldBeTrue();
         containerWithRegistrations.IsService(typeof(IList<ConcreteClass>)).ShouldBeTrue();
         containerWithRegistrations.IsService(typeof(List<ConcreteClass>)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void fix_for_405_add_support_for_net9()
+    {
+        var containerWithNoRegistrations = Container.Empty();
+
+        containerWithNoRegistrations.IsService(typeof(IEnumerable<object>)).ShouldBeTrue();
+        containerWithNoRegistrations.IsService(typeof(IEnumerable<string>)).ShouldBeTrue();
+        containerWithNoRegistrations.IsService(typeof(IEnumerable<int>)).ShouldBeTrue();
+        containerWithNoRegistrations.IsService(typeof(IEnumerable<int?>)).ShouldBeTrue();
+        containerWithNoRegistrations.IsService(typeof(IEnumerable<float>)).ShouldBeTrue();
+        containerWithNoRegistrations.IsService(typeof(IEnumerable<float?>)).ShouldBeTrue();
+        containerWithNoRegistrations.IsService(typeof(IEnumerable<double>)).ShouldBeTrue();
+        containerWithNoRegistrations.IsService(typeof(IEnumerable<double?>)).ShouldBeTrue();
+        containerWithNoRegistrations.IsService(typeof(IEnumerable<decimal>)).ShouldBeTrue();
+        containerWithNoRegistrations.IsService(typeof(IEnumerable<decimal?>)).ShouldBeTrue();
+        containerWithNoRegistrations.IsService(typeof(IEnumerable<DateTime>)).ShouldBeTrue();
+        containerWithNoRegistrations.IsService(typeof(IEnumerable<DateTime?>)).ShouldBeTrue();
+        containerWithNoRegistrations.IsService(typeof(IEnumerable<DateOnly?>)).ShouldBeTrue();
+        containerWithNoRegistrations.IsService(typeof(IEnumerable<DateOnly?>)).ShouldBeTrue();
+
+        containerWithNoRegistrations.IsService(typeof(IReadOnlyCollection<object>)).ShouldBeFalse();
+        containerWithNoRegistrations.IsService(typeof(IReadOnlyList<object>)).ShouldBeFalse();
+        containerWithNoRegistrations.IsService(typeof(IList<object>)).ShouldBeFalse();
+        containerWithNoRegistrations.IsService(typeof(List<object>)).ShouldBeFalse();
+
+        List<int> integerList = new List<int>();
+        
+        var containerWithRegistrations = Container.For(services =>
+                                                       {
+                                                           services.ForConcreteType<ConcreteClass>();
+                                                           services.For<IEnumerable<int>>().Use(integerList);
+                                                       });
+
+        containerWithRegistrations.IsService(typeof(IEnumerable<ConcreteClass>)).ShouldBeTrue();
+        containerWithRegistrations.IsService(typeof(IReadOnlyCollection<ConcreteClass>)).ShouldBeTrue();
+        containerWithRegistrations.IsService(typeof(IReadOnlyList<ConcreteClass>)).ShouldBeTrue();
+        containerWithRegistrations.IsService(typeof(IList<ConcreteClass>)).ShouldBeTrue();
+        containerWithRegistrations.IsService(typeof(List<ConcreteClass>)).ShouldBeTrue();
+        
+        containerWithRegistrations.IsService(typeof(IEnumerable<int>)).ShouldBeTrue();
+
+        containerWithRegistrations.GetInstance<IEnumerable<int>>().ShouldBeSameAs(integerList);
     }
 
     public interface IService

--- a/src/Lamar.Testing/Lamar.Testing.csproj
+++ b/src/Lamar.Testing/Lamar.Testing.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
         <LangVersion>10.0</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Lamar/Lamar.csproj
+++ b/src/Lamar/Lamar.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>Fast ASP.Net Core compatible IoC Tool, Successor to StructureMap</Description>
-        <Version>13.1.0</Version>
+        <Version>13.2.0</Version>
         <Authors>Jeremy D. Miller</Authors>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
         <DebugType>portable</DebugType>
         <AssemblyName>Lamar</AssemblyName>
         <PackageId>Lamar</PackageId>

--- a/src/Lamar/ServiceGraph.cs
+++ b/src/Lamar/ServiceGraph.cs
@@ -498,7 +498,7 @@ public class ServiceGraph : IDisposable, IAsyncDisposable
 
     private Type getServiceTypeThatTakesCollectionsIntoAccount(Type serviceType)
     {
-        if (!typeof(IEnumerable).IsAssignableFrom(serviceType) || serviceType.GetGenericArguments().Length != 1) 
+        if (!typeof(IEnumerable).IsAssignableFrom(serviceType) || serviceType.GetGenericArguments().Length != 1 || serviceType.GetGenericTypeDefinition() == typeof(IEnumerable<>)) 
             return serviceType;
 
         Type type = serviceType.GetGenericArguments().Single();
@@ -507,7 +507,7 @@ public class ServiceGraph : IDisposable, IAsyncDisposable
 
         return isTypeRegistered ? serviceType : type;
     }
-
+    
     internal void ClearPlanning()
     {
         _chain.Clear();

--- a/src/LamarWithAspNetCore3/LamarWithAspNetCore3.csproj
+++ b/src/LamarWithAspNetCore3/LamarWithAspNetCore3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/MinimalApiTests/MinimalApiTests.csproj
+++ b/src/MinimalApiTests/MinimalApiTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>

--- a/src/StructureMap.Testing.ExeWidget/StructureMap.Testing.ExeWidget.csproj
+++ b/src/StructureMap.Testing.ExeWidget/StructureMap.Testing.ExeWidget.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
     <AssemblyName>StructureMap.Testing.ExeWidget</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>StructureMap.Testing.ExeWidget</PackageId>

--- a/src/StructureMap.Testing.GenericWidgets/StructureMap.Testing.GenericWidgets.csproj
+++ b/src/StructureMap.Testing.GenericWidgets/StructureMap.Testing.GenericWidgets.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
     <AssemblyName>StructureMap.Testing.GenericWidgets</AssemblyName>
     <PackageId>StructureMap.Testing.GenericWidgets</PackageId>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/src/StructureMap.Testing.Widget/StructureMap.Testing.Widget.csproj
+++ b/src/StructureMap.Testing.Widget/StructureMap.Testing.Widget.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
     <AssemblyName>StructureMap.Testing.Widget</AssemblyName>
     <PackageId>StructureMap.Testing.Widget</PackageId>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/src/StructureMap.Testing.Widget2/StructureMap.Testing.Widget2.csproj
+++ b/src/StructureMap.Testing.Widget2/StructureMap.Testing.Widget2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
     <AssemblyName>StructureMap.Testing.Widget2</AssemblyName>
     <PackageId>StructureMap.Testing.Widget2</PackageId>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/src/StructureMap.Testing.Widget3/StructureMap.Testing.Widget3.csproj
+++ b/src/StructureMap.Testing.Widget3/StructureMap.Testing.Widget3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
     <AssemblyName>StructureMap.Testing.Widget3</AssemblyName>
     <PackageId>StructureMap.Testing.Widget3</PackageId>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/src/StructureMap.Testing.Widget4/StructureMap.Testing.Widget4.csproj
+++ b/src/StructureMap.Testing.Widget4/StructureMap.Testing.Widget4.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
     <AssemblyName>StructureMap.Testing.Widget4</AssemblyName>
     <PackageId>StructureMap.Testing.Widget4</PackageId>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.5' ">1.6.0</NetStandardImplicitPackageVersion>

--- a/src/StructureMap.Testing.Widget5/StructureMap.Testing.Widget5.csproj
+++ b/src/StructureMap.Testing.Widget5/StructureMap.Testing.Widget5.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
     <AssemblyName>StructureMap.Testing.Widget5</AssemblyName>
     <PackageId>StructureMap.Testing.Widget5</PackageId>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/src/Widget.Core/Widget.Core.csproj
+++ b/src/Widget.Core/Widget.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Widget.Instance/Widget.Instance.csproj
+++ b/src/Widget.Instance/Widget.Instance.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Widget.Registration/Widget.Registration.csproj
+++ b/src/Widget.Registration/Widget.Registration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request updates lamar to .net 9 and all of its dependencies, this should fix #405.

As already mentioned via discord, there seems to be a timing problem in asp.net core 9 in combination with lamar.

These tests in MinimalApiTests.integration_tests are red, it can be fixed when adding this two lines of code, after the call of .UseLamar(....) and builder.Build() and before the call of app.Run();

```csharp
var container = (IContainer)app.Services;
container.GetServices<Microsoft.AspNetCore.Diagnostics.IDeveloperPageExceptionFilter>();
````

**Note**
This workaround also works in real world asp.net core 9 applications.

**The error when running the tests or starting a real world asp.net core 9 application**
Unable to resolve service for type '**System.Collections.Generic.IEnumerable`1[Microsoft.AspNetCore.Diagnostics.IDeveloperPageExceptionFilter]**' while attempting to activate 'Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddlewareImpl'.
   at Microsoft.Extensions.DependencyInjection.ActivatorUtilities.ConstructorMatcher.CreateInstance(IServiceProvider provider)
   at Microsoft.Extensions.DependencyInjection.ActivatorUtilities.CreateInstance(IServiceProvider provider, Type instanceType, Object[] parameters)

I also added a break point in Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddlewareImpl and the IEnumerable<Microsoft.AspNetCore.Diagnostics.IDeveloperPageExceptionFilter> is always empty, so it's seems there is some kind of timing issue when using Lamar (therefore it's not a problem with a missing registration).

**Input from @jeremydmiller** 
Somehow the IEnumerable<Microsoft.AspNetCore.Diagnostics.IDeveloperPageExceptionFilter> is not even tried to be resolved by lamar (except when calling container.GetServices<Microsoft.AspNetCore.Diagnostics.IDeveloperPageExceptionFilter>(); before (maybe cached by aspnet.core)?)

**Edit**
Other dependencies are resolved by lamar
![image](https://github.com/user-attachments/assets/9d9d45a6-d357-4b01-b510-a13205a471e8)
![image](https://github.com/user-attachments/assets/e2346a48-33fb-4d6d-86fc-1ede50482d61)
![image](https://github.com/user-attachments/assets/5ac3aceb-1b74-4d0a-9b83-f870c0a63b1d)


But of course that isn't a real solution, any help would highly be appreciated.


