### PR TITLE
Use latest MS dependencies for each corresponding .net version

### DIFF
--- a/src/Lamar.AspNetCoreTests/Bugs/Bug_395_keyed_service_closed_generic_interface_registration_check.cs
+++ b/src/Lamar.AspNetCoreTests/Bugs/Bug_395_keyed_service_closed_generic_interface_registration_check.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace Lamar.AspNetCoreTests.Bugs;
 
+#if NET8_0_OR_GREATER
 public class Bug_395_keyed_service_closed_generic_interface_registration_check
 {
     class ClassA {}
@@ -46,3 +47,4 @@ public class Bug_395_keyed_service_closed_generic_interface_registration_check
         }
     }
 }
+#endif

--- a/src/Lamar.Microsoft.DependencyInjection/Lamar.Microsoft.DependencyInjection.csproj
+++ b/src/Lamar.Microsoft.DependencyInjection/Lamar.Microsoft.DependencyInjection.csproj
@@ -21,10 +21,24 @@
 		<ProjectReference Include="..\Lamar\Lamar.csproj" />
 	</ItemGroup>
 	
-	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[8.0.0,10.0.0)" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="[8.0.0,10.0.0)" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="[8.0.0,10.0.0)" />
-		<PackageReference Include="Microsoft.Extensions.Options" Version="[8.0.0,10.0.0)" />
-	</ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[9.0.0,10.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="[9.0.0,10.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="[9.0.0,10.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="[9.0.0,10.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[8.0.0,9.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="[8.0.0,9.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="[8.0.0,9.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="[8.0.0,9.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[7.0.0,8.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="[7.0.0,8.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="[7.0.0,8.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="[7.0.0,8.0.0)" />
+  </ItemGroup>
 </Project>

--- a/src/Lamar.Testing/IoC/Acceptance/IKeyedServiceProvider_compliance.cs
+++ b/src/Lamar.Testing/IoC/Acceptance/IKeyedServiceProvider_compliance.cs
@@ -8,7 +8,7 @@ namespace Lamar.Testing.IoC.Acceptance;
 
 public class IKeyedServiceProvider_compliance
 {
-    #region sample_adding_keyed_services
+    #if NET8_0_OR_GREATER
 
     [Fact]
     public void register_by_name_using_dot_net_core_syntax()
@@ -44,5 +44,5 @@ public class IKeyedServiceProvider_compliance
             .ShouldNotBeSameAs(container.GetKeyedService<CWidget>("C3"));
     }
 
-    #endregion
+    #endif
 }

--- a/src/Lamar/IServiceContext.cs
+++ b/src/Lamar/IServiceContext.cs
@@ -8,7 +8,10 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Lamar;
 
-public interface IServiceContext : IServiceProvider, IDisposable, IAsyncDisposable, IKeyedServiceProvider
+public interface IServiceContext : IServiceProvider, IDisposable, IAsyncDisposable
+#if NET8_0_OR_GREATER
+    , IKeyedServiceProvider
+#endif
 {
     /// <summary>
     ///     Provides queryable access to the configured serviceType's and Instances of this Container.

--- a/src/Lamar/IoC/Instances/Instance.cs
+++ b/src/Lamar/IoC/Instances/Instance.cs
@@ -106,10 +106,12 @@ public abstract class Instance
 
     public static Instance For(ServiceDescriptor service)
     {
+        #if NET8_0_OR_GREATER
         if (service.IsKeyedService)
         {
             var name = service.ServiceKey?.ToString();
             Instance instance = null;
+           
             if (service.KeyedImplementationInstance != null)
             {
                 instance = new ObjectInstance(service.ServiceType, service.KeyedImplementationInstance);
@@ -136,9 +138,8 @@ public abstract class Instance
             if (name.IsNotEmpty()) instance.Name = name;
             
             return instance;
-
-
         }
+        #endif
 
         
         if (service.ImplementationInstance is Instance i)

--- a/src/Lamar/Lamar.csproj
+++ b/src/Lamar/Lamar.csproj
@@ -22,8 +22,20 @@
 		<PackageReference Include="JasperFx.CodeGeneration" Version="3.7.0" />
 		<PackageReference Include="JasperFx.Core" Version="1.9.0" />
 		<PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
 	</ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
To prevent diamond dependency problems (MS dependencies), the latest versions of dependencies for the latest corresponding .net version should be used.

This should fix #407.