### PR TITLE
Use correct type for null singleton values

### DIFF
--- a/src/Lamar.Testing/Bugs/Bug_413_allow_user_defined_null_value.cs
+++ b/src/Lamar.Testing/Bugs/Bug_413_allow_user_defined_null_value.cs
@@ -1,0 +1,54 @@
+﻿using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Lamar.Testing.Bugs
+{
+    public class Bug_413_allow_user_defined_null_value
+    {
+        public interface IThing
+        {
+        }
+
+        public interface IThingConsumer
+        {
+            IThing Thing { get; }
+        }
+
+        public class ThingConsumer : IThingConsumer
+        {
+            public IThing Thing { get; private set; }
+            public ThingConsumer(IThing thing)
+            {
+                this.Thing = thing;
+            }
+        }
+
+        [Fact]
+        public void ShouldGetNullDependency_WhenDependencyResolvesToNullSingleton()
+        {
+            var container = new Container(x =>
+            {
+                x.For<IThing>().Use(null as IThing);//.Singleton();
+                x.For<IThingConsumer>().Use<ThingConsumer>();
+            });
+
+            var theThing = container.GetInstance<IThing>();
+
+            //This blows up when IThing is defined as null singleton/user defined variable in the registry
+            //Expression of type 'System.Object' cannot be used for constructor parameter of type 'typename+IThing' (Parameter 'arguments[0]')'
+            var thingConsumerByItsRegistration = container.GetInstance<IThingConsumer>();
+            var thingConsumerByConcrete = container.GetInstance<ThingConsumer>();
+
+            theThing.ShouldBeNull();
+            thingConsumerByItsRegistration.Thing.ShouldBeNull();
+            thingConsumerByItsRegistration.ShouldBeOfType<ThingConsumer>();
+            thingConsumerByConcrete.Thing.ShouldBeNull();
+            thingConsumerByConcrete.ShouldBeOfType<ThingConsumer>();
+        }
+    }
+}

--- a/src/Lamar/IoC/Frames/InjectedServiceField.cs
+++ b/src/Lamar/IoC/Frames/InjectedServiceField.cs
@@ -47,7 +47,7 @@ public class InjectedServiceField : InjectedField, IServiceVariable
         {
             var scope = definition.Context.As<Scope>();
             var @object = Instance.QuickResolve(scope);
-            return Expression.Constant(@object);
+            return Expression.Constant(@object, @object?.GetType() ?? Instance.ServiceType);
         }
 
         // This needs to be inlined singletons


### PR DESCRIPTION
Resolves #413 

This pull request addresses an issue related to resolving user-defined null values for dependencies. It includes a new test case to verify the behavior and modifies the `InjectedServiceField` class to ensure proper handling of null values during dependency resolution.
An exception Expression of type 'System.Object' cannot be used for constructor parameter of type 'IThing' (Parameter 'arguments[0]')' is thrown instead. The fix uses the object type or its intended type when the object is null

### Bug Fix: Handling Null Values in Dependency Resolution

* **New Test Case**: Added `Bug_413_allow_user_defined_null_value.cs` in `Lamar.Testing.Bugs` to verify that dependencies resolving to null (e.g., null singletons) are correctly handled without causing runtime exceptions. This test ensures that null dependencies are properly passed to consumers and validates their behavior.

* **Code Fix**: Updated the `ToVariableExpression` method in `InjectedServiceField.cs` to specify the type of the constant expression as either the resolved object's type (if not null) or the service type. This prevents runtime errors when the resolved object is null.