### PR TITLE
Fix: ServiceDescriptor.Lifetime now reflects intended lifetime for fluent registrations

### DIFF
--- a/src/Lamar.Testing/Bugs/Bug_descriptor_lifetime_for_fluent_use.cs
+++ b/src/Lamar.Testing/Bugs/Bug_descriptor_lifetime_for_fluent_use.cs
@@ -1,0 +1,126 @@
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Lamar.Testing.Bugs;
+
+// Repro for a bridge issue between Lamar's fluent registration API and the
+// IServiceCollection snapshot Lamar exposes (since ServiceRegistry : IServiceCollection).
+//
+// When a Lamar Instance is added to the registry via the extension at
+// src/Lamar/Scanning/Conventions/ServiceCollectionExtensions.cs:42-45:
+//
+//     public static void Add(this IServiceCollection services, Instance instance)
+//     {
+//         services.Add(new ServiceDescriptor(instance.ServiceType, instance));
+//     }
+//
+// the descriptor constructor used is ServiceDescriptor(Type, object) which
+// hard-codes ServiceLifetime.Singleton (it's the only MS-DI overload that
+// accepts a pre-existing instance). So every For<T>().Use<TImpl>() /
+// For<T>().Use(factory) / For<T>().Add<TImpl>() / ...Scoped() / ...Transient()
+// call writes a ServiceDescriptor whose Lifetime is Singleton, regardless of
+// what the underlying Lamar Instance says.
+//
+// Lamar itself still honors Instance.Lifetime when resolving, so apps that
+// only ever go through Container.GetInstance<T>() never see this. But anything
+// that reads the IServiceCollection snapshot directly (e.g. Wolverine 5+'s
+// HTTP endpoint code-gen, JasperFx's ServiceCollectionServerVariableSource)
+// sees Singleton and treats the registration accordingly. That's the
+// "Use existing HttpContext ServiceProvider for opaque scoped services"
+// scenario tracked at JasperFx/wolverine#1610 — for users of Lamar via
+// Wolverine HTTP it manifests as captive dependencies: a single resolved
+// instance baked into a singleton-lifetime generated handler class.
+//
+// This file demonstrates the underlying mismatch as plain xUnit tests against
+// Lamar alone, no Wolverine reference needed.
+public interface ILifetimeBridgeThing { }
+public class LifetimeBridgeThing : ILifetimeBridgeThing { }
+
+public class Bug_descriptor_lifetime_for_fluent_use
+{
+    // Convention-scan registrations (WithDefaultConventions()) are NOT affected:
+    // DefaultConventionScanner.ScanTypes calls the (serviceType, implType, lifetime)
+    // descriptor ctor directly at DefaultConventionScanner.cs:28, so the descriptor
+    // carries an honest lifetime. The bug below is specific to the fluent API paths
+    // that route through the Add(IServiceCollection, Instance) extension.
+
+    // ------- Fluent paths: descriptor.Lifetime is silently Singleton ----------
+
+    [Fact]
+    public void For_Use_writes_Transient_lifetime_to_descriptor()
+    {
+        // ServiceRegistry.For<T>() returns an InstanceExpression with
+        // ServiceLifetime.Transient as its default (ServiceRegistry.cs:96).
+        // The Instance Lamar adds also has Lifetime = Transient. But the
+        // ServiceDescriptor surfaced to IServiceCollection consumers will
+        // be Singleton.
+        var registry = new ServiceRegistry();
+        registry.For<ILifetimeBridgeThing>().Use<LifetimeBridgeThing>();
+
+        var descriptor = registry.LastOrDefault(d => d.ServiceType == typeof(ILifetimeBridgeThing));
+        descriptor.ShouldNotBeNull();
+        descriptor.Lifetime.ShouldBe(ServiceLifetime.Transient);
+    }
+
+    [Fact]
+    public void For_Use_Scoped_writes_Scoped_lifetime_to_descriptor()
+    {
+        // .Scoped() updates instance.Lifetime to Scoped (see
+        // InstanceExtensions.Scoped in ServiceRegistry.cs:23). The descriptor
+        // still ends up Singleton.
+        var registry = new ServiceRegistry();
+        registry.For<ILifetimeBridgeThing>().Use<LifetimeBridgeThing>().Scoped();
+
+        var descriptor = registry.LastOrDefault(d => d.ServiceType == typeof(ILifetimeBridgeThing));
+        descriptor.ShouldNotBeNull();
+        descriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
+    }
+
+    [Fact]
+    public void For_Use_factory_Scoped_writes_Scoped_lifetime_to_descriptor()
+    {
+        // The lambda-factory overload — same bug. This is the exact shape
+        // that AMI uses to register IAsyncDocumentSession against RavenDB
+        // and that triggers captive sessions in Wolverine HTTP handlers.
+        var registry = new ServiceRegistry();
+        registry.For<ILifetimeBridgeThing>().Use(_ => new LifetimeBridgeThing()).Scoped();
+
+        var descriptor = registry.LastOrDefault(d => d.ServiceType == typeof(ILifetimeBridgeThing));
+        descriptor.ShouldNotBeNull();
+        descriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
+    }
+
+    [Fact]
+    public void For_Add_writes_Transient_lifetime_to_descriptor()
+    {
+        // The multi-impl pipeline form. Same bridge path.
+        var registry = new ServiceRegistry();
+        registry.For<ILifetimeBridgeThing>().Add<LifetimeBridgeThing>();
+
+        var descriptor = registry.LastOrDefault(d => d.ServiceType == typeof(ILifetimeBridgeThing));
+        descriptor.ShouldNotBeNull();
+        descriptor.Lifetime.ShouldBe(ServiceLifetime.Transient);
+    }
+
+    // ------- Sanity: container resolution honours intent (the consolation) ---
+
+    [Fact]
+    public void Container_resolution_still_honours_intended_lifetime()
+    {
+        // Lamar's own container plan uses Instance.Lifetime correctly, so this
+        // passes today. Documenting it to make clear the bug is purely at the
+        // IServiceCollection-snapshot layer.
+        var container = new Container(x => x.For<ILifetimeBridgeThing>().Use<LifetimeBridgeThing>().Scoped());
+
+        using var scope1 = container.GetNestedContainer();
+        using var scope2 = container.GetNestedContainer();
+        var a1 = scope1.GetInstance<ILifetimeBridgeThing>();
+        var a2 = scope1.GetInstance<ILifetimeBridgeThing>();
+        var b1 = scope2.GetInstance<ILifetimeBridgeThing>();
+
+        a1.ShouldBeSameAs(a2);   // same scope -> same instance
+        a1.ShouldNotBeSameAs(b1); // different scope -> different instance
+    }
+}

--- a/src/Lamar.Testing/IoC/ServiceRegistryTests.cs
+++ b/src/Lamar.Testing/IoC/ServiceRegistryTests.cs
@@ -4,6 +4,7 @@ using JasperFx.CodeGeneration.Model;
 using Lamar.IoC;
 using Lamar.IoC.Frames;
 using Lamar.IoC.Instances;
+using Lamar.Scanning.Conventions;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 using StructureMap.Testing.Widget;
@@ -22,7 +23,7 @@ public class ServiceRegistryTests
 
         registry.For<IWidget>().Use(custom);
 
-        registry.Single().ImplementationInstance.ShouldBe(custom);
+        registry.Single().LamarInstance().ShouldBe(custom);
     }
 }
 

--- a/src/Lamar.Testing/Scanning/Conventions/ServiceCollectionExtensionsTests.cs
+++ b/src/Lamar.Testing/Scanning/Conventions/ServiceCollectionExtensionsTests.cs
@@ -29,7 +29,7 @@ public class ServiceCollectionExtensionsTests
 
         var widgetDescriptor = services.Single(x => x.ServiceType == typeof(IWidget));
         widgetDescriptor.ServiceType.ShouldBe(typeof(IWidget));
-        widgetDescriptor.ImplementationInstance.As<Instance>().ImplementationType.ShouldBe(typeof(AWidget));
+        widgetDescriptor.LamarInstance().ImplementationType.ShouldBe(typeof(AWidget));
     }
 
     [Fact]
@@ -42,7 +42,7 @@ public class ServiceCollectionExtensionsTests
         services.AddType(typeof(IWidget), typeof(MoneyWidget));
 
         services.Where(x => x.ServiceType == typeof(IWidget))
-            .Select(x => x.ImplementationInstance).OfType<Instance>().Select(x => x.ImplementationType)
+            .Select(x => x.LamarInstance()).Where(x => x != null).Select(x => x.ImplementationType)
             .ShouldHaveTheSameElementsAs(typeof(AWidget), typeof(MoneyWidget));
     }
 
@@ -58,7 +58,7 @@ public class ServiceCollectionExtensionsTests
         services.AddType(typeof(IWidget), typeof(MoneyWidget));
 
         services.Where(x => x.ServiceType == typeof(IWidget))
-            .Select(x => x.ImplementationInstance).OfType<Instance>().Select(x => x.ImplementationType)
+            .Select(x => x.LamarInstance()).Where(x => x != null).Select(x => x.ImplementationType)
             .ShouldHaveTheSameElementsAs(typeof(AWidget), typeof(MoneyWidget));
     }
 }

--- a/src/Lamar.Testing/ServiceRegistryTester.cs
+++ b/src/Lamar.Testing/ServiceRegistryTester.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using Lamar.IoC.Instances;
+using Lamar.Scanning.Conventions;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 using StructureMap.Testing.Widget;
@@ -17,7 +18,7 @@ public class ServiceRegistryTester
 
         var descriptor = registry.Single();
 
-        var instance = descriptor.ImplementationInstance.ShouldBeOfType<ConstructorInstance<AWidget, IWidget>>();
+        var instance = descriptor.LamarInstance().ShouldBeOfType<ConstructorInstance<AWidget, IWidget>>();
         instance.ImplementationType.ShouldBe(typeof(AWidget));
 
         descriptor.ServiceType.ShouldBe(typeof(IWidget));
@@ -31,7 +32,7 @@ public class ServiceRegistryTester
 
         var descriptor = registry.Single();
 
-        var instance = descriptor.ImplementationInstance.ShouldBeOfType<ConstructorInstance<AWidget, IWidget>>();
+        var instance = descriptor.LamarInstance().ShouldBeOfType<ConstructorInstance<AWidget, IWidget>>();
         instance.ImplementationType.ShouldBe(typeof(AWidget));
         instance.Lifetime.ShouldBe(ServiceLifetime.Singleton);
 

--- a/src/Lamar/IoC/Instances/Instance.cs
+++ b/src/Lamar/IoC/Instances/Instance.cs
@@ -7,6 +7,7 @@ using JasperFx.CodeGeneration.Model;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using Lamar.IoC.Frames;
+using Lamar.Scanning.Conventions;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Lamar.IoC.Instances;
@@ -34,13 +35,40 @@ public abstract class Instance
 
     public bool IsExplicitlyNamed { get; set; }
 
+    // Set when ServiceCollectionExtensions.Add wraps the Instance in a
+    // LamarServiceDescriptor. Together they let the Lifetime setter (below) keep the
+    // descriptor's surface-area Lifetime in sync with this Instance — needed because
+    // the MS-DI ServiceDescriptor is immutable, so any Lifetime change requires
+    // replacing the descriptor in the registry.
+    internal IServiceCollection ServiceCollection { get; set; }
+    internal LamarServiceDescriptor LamarDescriptor { get; set; }
+
 
     public Type ServiceType { get; }
     public Type ImplementationType { get; }
 
     public int Hash { get; set; }
 
-    public ServiceLifetime Lifetime { get; set; } = ServiceLifetime.Transient;
+    private ServiceLifetime _lifetime = ServiceLifetime.Transient;
+
+    /// <summary>
+    ///     Intended lifetime of this Instance. Mutating this value also refreshes
+    ///     the backing LamarServiceDescriptor in the registry so IServiceCollection
+    ///     consumers (Wolverine code-gen, MS-DI validation, etc.) see the current
+    ///     lifetime. All Lifetime mutations — fluent .Scoped()/.Transient()/.Singleton(),
+    ///     ReferencedInstance.createPlan's Lifetime = _inner.Lifetime, internal
+    ///     adjustments — route through this single setter.
+    /// </summary>
+    public ServiceLifetime Lifetime
+    {
+        get => _lifetime;
+        set
+        {
+            if (_lifetime == value) return;
+            _lifetime = value;
+            this.ReplaceLamarDescriptor();
+        }
+    }
 
     public string Name
     {
@@ -147,9 +175,10 @@ public abstract class Instance
         #endif
 
         
-        if (service.ImplementationInstance is Instance i)
+        var lamarInstance = service.LamarInstance();
+        if (lamarInstance != null)
         {
-            return i;
+            return lamarInstance;
         }
 
         if (service.ImplementationInstance != null)

--- a/src/Lamar/LamarServiceDescriptor.cs
+++ b/src/Lamar/LamarServiceDescriptor.cs
@@ -1,3 +1,4 @@
+using System;
 using Lamar.IoC.Instances;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -15,21 +16,36 @@ namespace Lamar;
 ///     resolved Lamar registrations as singleton fields on generated handler
 ///     classes; see JasperFx/wolverine#1610 and #537 for visible symptoms.
 ///
-///     The subclass routes the Instance through Lamar-specific state, while
-///     delegating to the (Type, Type, ServiceLifetime) base constructor so the
-///     descriptor's surface-area Lifetime is honest. Lamar's own self-discovery
-///     in <see cref="Instance.FindServiceRegistration" /> (and the related
-///     Matches helper) prefers the typed Instance when present and otherwise
-///     reconstructs from the descriptor's ImplementationType / Lifetime — the
-///     two paths produce equivalent results for simple registrations.
+///     Descriptor shape: we delegate to the (Type, Func, ServiceLifetime) base
+///     constructor, which makes the descriptor look like an "opaque lambda
+///     factory" to external consumers. This is the shape Wolverine's docs say
+///     triggers service-location at runtime — exactly what we want, because
+///     service location calls back into Lamar's IServiceProvider, which can
+///     see scan-only deps (whereas Wolverine's inline-construction codegen
+///     cannot). The factory delegate itself is never invoked under Lamar
+///     resolution: Lamar's <see cref="Instance.For" /> checks for the subclass
+///     first and returns the typed Instance directly, bypassing the factory
+///     branch. The factory body throws to make any incorrect direct invocation
+///     loud and obvious.
 /// </summary>
 public sealed class LamarServiceDescriptor : ServiceDescriptor
 {
     public LamarServiceDescriptor(Instance instance)
-        : base(instance.ServiceType, instance.ImplementationType ?? instance.ServiceType, instance.Lifetime)
+        : base(
+            instance.ServiceType,
+            FactoryShouldNotBeInvoked,
+            instance.Lifetime)
     {
         Instance = instance;
     }
 
     public Instance Instance { get; }
+
+    private static object FactoryShouldNotBeInvoked(IServiceProvider sp) =>
+        throw new InvalidOperationException(
+            "LamarServiceDescriptor's ImplementationFactory is a Wolverine/MS-DI codegen marker " +
+            "and should not be invoked directly. Resolution under Lamar goes through Instance.For " +
+            "(which prefers the typed Instance on the subclass) and never through this delegate. " +
+            "If you see this, you are resolving the descriptor outside a Lamar container — build " +
+            "the container via UseLamar(...) instead of stock MS-DI ServiceProvider.");
 }

--- a/src/Lamar/LamarServiceDescriptor.cs
+++ b/src/Lamar/LamarServiceDescriptor.cs
@@ -1,0 +1,35 @@
+using Lamar.IoC.Instances;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Lamar;
+
+/// <summary>
+///     ServiceDescriptor variant that carries a Lamar Instance alongside its
+///     intended ServiceLifetime. This solves a long-standing mismatch: the
+///     stock ServiceDescriptor(Type, object) constructor — which is the only
+///     MS-DI overload that accepts a pre-existing object payload — hard-codes
+///     Lifetime = Singleton, forcing every fluent registration (For<T>().Use<TImpl>(),
+///     .Use(factory), .Add<TImpl>(), and their .Scoped()/.Transient() variants)
+///     to appear as a Singleton to anything inspecting the IServiceCollection
+///     snapshot. That's the root cause behind Wolverine HTTP code-gen capturing
+///     resolved Lamar registrations as singleton fields on generated handler
+///     classes; see JasperFx/wolverine#1610 and #537 for visible symptoms.
+///
+///     The subclass routes the Instance through Lamar-specific state, while
+///     delegating to the (Type, Type, ServiceLifetime) base constructor so the
+///     descriptor's surface-area Lifetime is honest. Lamar's own self-discovery
+///     in <see cref="Instance.FindServiceRegistration" /> (and the related
+///     Matches helper) prefers the typed Instance when present and otherwise
+///     reconstructs from the descriptor's ImplementationType / Lifetime — the
+///     two paths produce equivalent results for simple registrations.
+/// </summary>
+public sealed class LamarServiceDescriptor : ServiceDescriptor
+{
+    public LamarServiceDescriptor(Instance instance)
+        : base(instance.ServiceType, instance.ImplementationType ?? instance.ServiceType, instance.Lifetime)
+    {
+        Instance = instance;
+    }
+
+    public Instance Instance { get; }
+}

--- a/src/Lamar/Scanning/Conventions/ServiceCollectionExtensions.cs
+++ b/src/Lamar/Scanning/Conventions/ServiceCollectionExtensions.cs
@@ -35,13 +35,60 @@ internal static class ServiceCollectionExtensions
     }
 
     /// <summary>
-    ///     Add a registration via Lamar's intrinsic Instance type
+    ///     Add a registration via Lamar's intrinsic Instance type.
+    ///
+    ///     Lamar smuggles its rich Instance metadata through ServiceDescriptor by
+    ///     placing the Instance object in the ImplementationInstance slot. The
+    ///     built-in MS-DI ServiceDescriptor(Type, object) constructor forces
+    ///     Lifetime = Singleton, which lies to any IServiceCollection consumer
+    ///     (Wolverine code-gen in particular) that reads descriptor.Lifetime to
+    ///     decide how to source the dependency. We use a LamarServiceDescriptor
+    ///     subclass so the descriptor carries the Lamar Instance AND the intended
+    ///     lifetime; Lamar's own self-discovery treats it the same as a legacy
+    ///     ImplementationInstance round-trip via the helper below.
     /// </summary>
     /// <param name="services"></param>
     /// <param name="instance"></param>
     public static void Add(this IServiceCollection services, Instance instance)
     {
-        services.Add(new ServiceDescriptor(instance.ServiceType, instance));
+        var descriptor = new LamarServiceDescriptor(instance);
+        instance.ServiceCollection = services;
+        instance.LamarDescriptor = descriptor;
+        services.Add(descriptor);
+    }
+
+    /// <summary>
+    ///     Called by <see cref="Instance.Lifetime" />'s setter when the lifetime changes.
+    ///     Locates the Instance's existing LamarServiceDescriptor in the registry by
+    ///     reference and replaces it with a fresh one reflecting current Instance state.
+    ///     Matches by descriptor reference (not by ServiceType, which is what MS-DI's
+    ///     own <c>IServiceCollection.Replace</c> extension does — wrong semantics for us
+    ///     when multiple registrations share a ServiceType, e.g. <c>For&lt;T&gt;().Add&lt;&gt;()</c>
+    ///     pipelines).
+    /// </summary>
+    internal static void ReplaceLamarDescriptor(this Instance instance)
+    {
+        var services = instance.ServiceCollection;
+        var current = instance.LamarDescriptor;
+        if (services == null || current == null) return;
+
+        var idx = services.IndexOf(current);
+        if (idx < 0) return;
+
+        var refreshed = new LamarServiceDescriptor(instance);
+        services[idx] = refreshed;
+        instance.LamarDescriptor = refreshed;
+    }
+
+    /// <summary>
+    ///     Returns the Lamar Instance attached to <paramref name="descriptor" />, if any —
+    ///     covering both the LamarServiceDescriptor subclass and the legacy
+    ///     ImplementationInstance round-trip shape.
+    /// </summary>
+    internal static Instance LamarInstance(this ServiceDescriptor descriptor)
+    {
+        if (descriptor is LamarServiceDescriptor lsd) return lsd.Instance;
+        return descriptor.ImplementationInstance as Instance;
     }
 
     public static bool Matches(this ServiceDescriptor descriptor, Type serviceType, Type implementationType)
@@ -56,9 +103,10 @@ internal static class ServiceCollectionExtensions
             return true;
         }
 
-        if (descriptor.ImplementationInstance is Instance)
+        var lamarInstance = descriptor.LamarInstance();
+        if (lamarInstance != null)
         {
-            return descriptor.ImplementationInstance.As<Instance>().ImplementationType == implementationType;
+            return lamarInstance.ImplementationType == implementationType;
         }
 
         return false;

--- a/src/Lamar/ServiceRegistry.HashCollisionMitigation.cs
+++ b/src/Lamar/ServiceRegistry.HashCollisionMitigation.cs
@@ -1,5 +1,6 @@
 ﻿using Lamar.IoC;
 using Lamar.IoC.Instances;
+using Lamar.Scanning.Conventions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -74,8 +75,8 @@ public partial class ServiceRegistry
 
     internal IEnumerable<IGrouping<int, Instance>> GetInstanceHashCollisions()
     {
-        return this.Select(x => x.ImplementationInstance)
-            .OfType<Instance>()
+        return this.Select(x => x.LamarInstance())
+            .Where(x => x != null)
             .GroupBy(x => x.Hash)
             .Where(x => x.Select(y => y.ServiceType).Distinct().Count() > 1);
     }


### PR DESCRIPTION
Closes JasperFx/lamar#428.

This is the fix for the bridge issue described in the linked issue — where every fluent registration (`For<T>().Use<TImpl>()`, `.Use(factory)`, `.Add<TImpl>()`, and their `.Scoped()` / `.Transient()` / `.Singleton()` variants) produced a `ServiceDescriptor` whose `Lifetime` was hard-coded to `Singleton`, regardless of what the underlying `Instance` reported.

## Approach

We've added internal plumbing in Lamar so that whenever a lifetime method runs on an `Instance` — fluent `.Scoped()` / `.Transient()` / `.Singleton()`, planning-time adjustments, attribute-driven overrides, or any other source — the descriptor already in the `IServiceCollection` is updated to reflect the new lifetime. Consumers reading the registry always see a descriptor whose `Lifetime` matches the Instance's current state, both at registration time and after any subsequent change. Lamar's own resolution continues to read from the `Instance` directly; nothing about the runtime hot path changes. Details below.

## How this addresses each complexity from [#428](https://github.com/JasperFx/lamar/issues/428)

### 1. `ServiceDescriptor` has no built-in ctor accepting both an instance and a non-Singleton lifetime

**Subclass it.** New `LamarServiceDescriptor : ServiceDescriptor` adds a typed `public Instance Instance { get; }` property to carry the Lamar metadata, separate from the base class's `ImplementationInstance` / `ImplementationType` / `ImplementationFactory` slots. The base constructor we delegate to is `(Type serviceType, Func<IServiceProvider, object> factory, ServiceLifetime lifetime)` — which respects `lifetime` honestly (no Singleton lock) and decouples the metadata payload from the descriptor's "shape" signals.

### 2. Lamar's `ServiceGraph` self-discovery depends on the Instance round-trip

**Subclass check first.** `Instance.For(ServiceDescriptor)` gains a new first branch via a `LamarInstance()` extension that returns `lsd.Instance` for any `LamarServiceDescriptor`, falling through to the legacy `ImplementationInstance is Instance` round-trip only for non-Lamar descriptors. The same helper is used in `Matches()` and `ServiceRegistry.HashCollisionMitigation` so all of Lamar's self-discovery paths continue to see the rich `Instance` (Name, decorators, immediate dependencies, IsKeyedService, IConfiguredInstance state, …). Nothing inside Lamar reads `ImplementationFactory` or `ImplementationType` from these descriptors — the subclass branch always wins.

### 3. Lamar's fluent chain commits eagerly with no chain-state mechanism

**Replace the descriptor in place when state changes.** The bridge `Add(IServiceCollection, Instance)` extension records two back-pointers on the `Instance` itself: the `IServiceCollection` it was added to and the specific `LamarServiceDescriptor` reference. A new internal extension `ReplaceLamarDescriptor()` uses `IList<ServiceDescriptor>.IndexOf(currentDescriptor)` to find the descriptor by reference (not by `ServiceType`, which is wrong for `For<T>().Add<>().Add<>()` multi-impl pipelines — exactly the trap MS-DI's own `IServiceCollection.Replace` extension falls into) and swap it for a fresh `LamarServiceDescriptor` reflecting the Instance's current state.

### 4. `Instance.Lifetime` is mutated from many places

**Single mutation point via a property setter.** `Instance.Lifetime` becomes a real property with a backing field; its setter calls `ReplaceLamarDescriptor()` whenever the lifetime actually changes. This catches all ~13 assignment sites in the source — fluent `.Scoped()` / `.Transient()` / `.Singleton()`, `ReferencedInstance.createPlan`'s `Lifetime = _inner.Lifetime`, `[Scoped]` / `[Singleton]` attribute handlers, `InterceptingInstance` / `ActivatingInstance` activation policies, `ServiceFamily` decorator handling, and the `InstanceExpression`'s `_lifetime` propagation. No per-call-site refresh helpers are needed in any of them.

(I considered tightening `Instance.Lifetime`'s setter to `protected internal` so external code can't mutate it directly, but `IConfiguredInstance.Lifetime { get; set; }` is a public interface contract — so it stays `public { get; set; }` with a notifying setter. Happy to make it a `SetLifetime(value)` method + read-only property in a follow-up if you'd prefer.)

### 5. The descriptor's shape drives downstream code-gen, not just its lifetime

**Factory-shape base ctor, not concrete-type-shape.** The first version of this fix used the `(Type, Type, ServiceLifetime)` base ctor — which set `descriptor.ImplementationType` and tells Wolverine "inline-construct this". That made Wolverine walk the impl's constructor chain at code-gen and fail with `NotSupportedException: Cannot build service type ... in any way` whenever a transitive ctor parameter was registered only via Lamar's convention scan (because scan-only registrations don't surface to the `IServiceCollection` snapshot Wolverine reads).

The current shape uses the `(Type, Func<IServiceProvider, object>, ServiceLifetime)` base ctor, which sets `descriptor.ImplementationFactory` and presents to Wolverine as an "opaque lambda factory" with Scoped/Transient lifetime — exactly the shape that, per [Wolverine's code-gen docs](https://wolverinefx.net/guide/codegen), triggers service-location at runtime. Service location calls back into Lamar's `IServiceProvider`, which can resolve scan-only deps. The factory delegate itself is never invoked under correct usage: Wolverine doesn't call it (it emits `sp.GetRequiredService<T>()` directly), and Lamar's resolution returns the typed `Instance` from the subclass before the `ImplementationFactory` branch runs. The delegate body throws with a diagnostic message if called, to make any misuse loud.

## Other Notes

- The factory delegate carries a diagnostic-only throw; it's intentionally unreachable under correct Lamar resolution. If you'd prefer it return `serviceProvider.GetService(serviceType)` for defense-in-depth against direct stock-MS-DI usage, that's a one-line change.
- I considered an alternative shape that reconciles descriptor lifetimes at `ServiceGraph.organize()` time instead of via the `Instance.Lifetime` setter, but rejected it: it leaves a window between registration and Container construction where the descriptor still reports the stale lifetime. Any consumer that reads the registry during that window — and Wolverine's HTTP setup pipeline plausibly does, depending on ordering — would see wrong values. The setter-driven approach in this PR keeps the descriptor honest at every moment, with no in-flight inconsistency.

## Verification

- All 5 tests in `src/Lamar.Testing/Bugs/Bug_descriptor_lifetime_for_fluent_use.cs` pass.
- All **714** tests in `Lamar.Testing` pass on net9.0 and net10.0 (711 on net8.0).
- All **23** tests in `Lamar.AspNetCoreTests` pass on all three TFMs.
- Eleven pre-existing tests asserted directly on the legacy `ImplementationInstance is Instance` round-trip; they've been updated to use the new internal `LamarInstance()` helper. Semantics unchanged.
