### PR TITLE
Target .NET 9 / .NET 10 and bump to 16.0.0

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -30,10 +30,6 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 9.0.x
-    - name: Setup .NET 8
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 8.0.x
 
 
     - name: Test

--- a/.github/workflows/publish_lamar.yml
+++ b/.github/workflows/publish_lamar.yml
@@ -20,11 +20,6 @@ jobs:
       with:
         dotnet-version: 9.0.x
 
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 8.0.x
-
     - name: Build
       run: dotnet build Lamar.sln --configuration Release
 

--- a/src/Aspect.Logger/Widget.Aspect.Logger.csproj
+++ b/src/Aspect.Logger/Widget.Aspect.Logger.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Lamar.AspNetCoreTests.Integration/Lamar.AspNetCoreTests.Integration.csproj
+++ b/src/Lamar.AspNetCoreTests.Integration/Lamar.AspNetCoreTests.Integration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFrameworks>net9.0;net10.0</TargetFrameworks>
 
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
@@ -15,24 +15,6 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="coverlet.collector" Version="1.0.1" />
-	</ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="[6.0.0,7.0.0)" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="[6.0.0,7.0.0)" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[6.0.0,7.0.0)" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="[6.0.0,7.0.0)" />
-		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[6.0.0,7.0.0)" />
-		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="[6.0.0,7.0.0)" />
-	</ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="[8.0.0,9.0.0)" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="[8.0.0,9.0.0)" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[8.0.0,9.0.0)" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="[8.0.0,9.0.0)" />
-		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[8.0.0,9.0.0)" />
-		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="[8.0.0,9.0.0)" />
 	</ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">

--- a/src/Lamar.AspNetCoreTests/Lamar.AspNetCoreTests.csproj
+++ b/src/Lamar.AspNetCoreTests/Lamar.AspNetCoreTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFrameworks>net9.0;net10.0</TargetFrameworks>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 	
@@ -21,15 +21,7 @@
 		<PackageReference Include="Shouldly" Version="4.2.1" />
 	</ItemGroup>
 
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-		<PackageReference Include=" Microsoft.Extensions.Diagnostics.HealthChecks" Version="[6.0.0,7.0.0)" />
-	</ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-		<PackageReference Include=" Microsoft.Extensions.Diagnostics.HealthChecks" Version="[8.0.0,9.0.0)" />
-	</ItemGroup>
-
-	<ItemGroup>
+<ItemGroup>
 		<ProjectReference Include="..\Lamar.Microsoft.DependencyInjection\Lamar.Microsoft.DependencyInjection.csproj" />
 	</ItemGroup>
 

--- a/src/Lamar.Microsoft.DependencyInjection/Lamar.Microsoft.DependencyInjection.csproj
+++ b/src/Lamar.Microsoft.DependencyInjection/Lamar.Microsoft.DependencyInjection.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>Lamar Adapter for HostBuilder Integration</Description>
-        <Version>15.1.0</Version>
+        <Version>16.0.0</Version>
         <Authors>Jeremy D. Miller</Authors>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <DebugType>portable</DebugType>
         <AssemblyName>Lamar.Microsoft.DependencyInjection</AssemblyName>
         <PackageId>Lamar.Microsoft.DependencyInjection</PackageId>

--- a/src/Lamar.Testing/Lamar.Testing.csproj
+++ b/src/Lamar.Testing/Lamar.Testing.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <LangVersion>10.0</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Lamar/IoC/Enumerables/ArrayInstance.cs
+++ b/src/Lamar/IoC/Enumerables/ArrayInstance.cs
@@ -63,7 +63,13 @@ public class ArrayInstance<T> : GeneratedInstance, IEnumerableInstance
         }
         else
         {
-            Elements = services.FindAll(typeof(T));
+            // MS DI's IServiceProvider.GetServices(T) (and by extension T[] resolution) returns
+            // only non-keyed registrations; keyed registrations are looked up explicitly via
+            // GetKeyedService(T, key). Match that here so a keyed-mirror registration of the
+            // same service type doesn't end up as a T[] element. Otherwise inlining the
+            // mirror's Singleton via QuickResolve invokes the mirror's factory, which calls
+            // sp.GetServices(T) again and recursively re-enters codegen — stack overflow.
+            Elements = services.FindAll(typeof(T)).Where(x => !x.IsKeyedService).ToArray();
         }
 
         return Elements;

--- a/src/Lamar/IoC/Enumerables/ListInstance.cs
+++ b/src/Lamar/IoC/Enumerables/ListInstance.cs
@@ -56,7 +56,13 @@ public class ListInstance<T> : GeneratedInstance, IEnumerableInstance
         }
         else
         {
-            Elements = services.FindAll(typeof(T));
+            // MS DI's IServiceProvider.GetServices(T) returns only non-keyed registrations;
+            // keyed registrations are looked up explicitly via GetKeyedService(T, key). Match
+            // that here so a keyed-mirror registration of the same service type doesn't end up
+            // as an IEnumerable<T> element. Otherwise inlining the mirror's Singleton via
+            // QuickResolve invokes the mirror's factory, which calls sp.GetServices(T) again
+            // and recursively re-enters ListInstance/ArrayInstance code-gen — stack overflow.
+            Elements = services.FindAll(typeof(T)).Where(x => !x.IsKeyedService).ToArray();
         }
 
         return Elements;

--- a/src/Lamar/Lamar.csproj
+++ b/src/Lamar/Lamar.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>Fast ASP.Net Core compatible IoC Tool, Successor to StructureMap</Description>
-        <Version>15.1.0</Version>
+        <Version>16.0.0</Version>
         <Authors>Jeremy D. Miller</Authors>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <DebugType>portable</DebugType>
         <AssemblyName>Lamar</AssemblyName>
         <PackageId>Lamar</PackageId>
@@ -24,12 +24,6 @@
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0"/>
-    </ItemGroup>
-
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0"/>
-        <PackageReference Include="System.Runtime.Loader" Version="4.3.0"/>
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/LamarDiagnosticsWithNetCore3Demonstrator/LamarDiagnosticsWithNetCore3Demonstrator.csproj
+++ b/src/LamarDiagnosticsWithNetCore3Demonstrator/LamarDiagnosticsWithNetCore3Demonstrator.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/LamarWithAspNetCore3/LamarWithAspNetCore3.csproj
+++ b/src/LamarWithAspNetCore3/LamarWithAspNetCore3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/LamarWithAspNetCoreMvc3/LamarWithAspNetCoreMvc3.csproj
+++ b/src/LamarWithAspNetCoreMvc3/LamarWithAspNetCoreMvc3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     </PropertyGroup>
 
 

--- a/src/LamarWithIdentityOnNet5/LamarWithIdentityOnNet5.csproj
+++ b/src/LamarWithIdentityOnNet5/LamarWithIdentityOnNet5.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/LamarWithMinimalApiOnNet6/LamarWithMinimalApiOnNet6.csproj
+++ b/src/LamarWithMinimalApiOnNet6/LamarWithMinimalApiOnNet6.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFrameworks>net9.0;net10.0</TargetFrameworks>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 

--- a/src/MinimalApiTests/MinimalApiTests.csproj
+++ b/src/MinimalApiTests/MinimalApiTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>

--- a/src/StructureMap.Testing.ExeWidget/StructureMap.Testing.ExeWidget.csproj
+++ b/src/StructureMap.Testing.ExeWidget/StructureMap.Testing.ExeWidget.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <AssemblyName>StructureMap.Testing.ExeWidget</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>StructureMap.Testing.ExeWidget</PackageId>

--- a/src/StructureMap.Testing.GenericWidgets/StructureMap.Testing.GenericWidgets.csproj
+++ b/src/StructureMap.Testing.GenericWidgets/StructureMap.Testing.GenericWidgets.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <AssemblyName>StructureMap.Testing.GenericWidgets</AssemblyName>
     <PackageId>StructureMap.Testing.GenericWidgets</PackageId>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/src/StructureMap.Testing.Widget/StructureMap.Testing.Widget.csproj
+++ b/src/StructureMap.Testing.Widget/StructureMap.Testing.Widget.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <AssemblyName>StructureMap.Testing.Widget</AssemblyName>
     <PackageId>StructureMap.Testing.Widget</PackageId>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/src/StructureMap.Testing.Widget2/StructureMap.Testing.Widget2.csproj
+++ b/src/StructureMap.Testing.Widget2/StructureMap.Testing.Widget2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <AssemblyName>StructureMap.Testing.Widget2</AssemblyName>
     <PackageId>StructureMap.Testing.Widget2</PackageId>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/src/StructureMap.Testing.Widget3/StructureMap.Testing.Widget3.csproj
+++ b/src/StructureMap.Testing.Widget3/StructureMap.Testing.Widget3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <AssemblyName>StructureMap.Testing.Widget3</AssemblyName>
     <PackageId>StructureMap.Testing.Widget3</PackageId>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/src/StructureMap.Testing.Widget4/StructureMap.Testing.Widget4.csproj
+++ b/src/StructureMap.Testing.Widget4/StructureMap.Testing.Widget4.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <AssemblyName>StructureMap.Testing.Widget4</AssemblyName>
     <PackageId>StructureMap.Testing.Widget4</PackageId>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.5' ">1.6.0</NetStandardImplicitPackageVersion>

--- a/src/StructureMap.Testing.Widget5/StructureMap.Testing.Widget5.csproj
+++ b/src/StructureMap.Testing.Widget5/StructureMap.Testing.Widget5.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <AssemblyName>StructureMap.Testing.Widget5</AssemblyName>
     <PackageId>StructureMap.Testing.Widget5</PackageId>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/src/UserApp/UserApp.csproj
+++ b/src/UserApp/UserApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
 

--- a/src/Widget.Core/Widget.Core.csproj
+++ b/src/Widget.Core/Widget.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Widget.Instance/Widget.Instance.csproj
+++ b/src/Widget.Instance/Widget.Instance.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Widget.Registration/Widget.Registration.csproj
+++ b/src/Widget.Registration/Widget.Registration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Target .NET 9 / .NET 10 and bump to 16.0.0

Closes #427

### What changed
- **Dropped every target framework below .NET 9** across the solution. All multi-targeted projects move from `net8.0;net9.0;net10.0` to `net9.0;net10.0`.
- **Published nugets now target `net9.0;net10.0`** and are bumped to **16.0.0**:
  - `Lamar`
  - `Lamar.Microsoft.DependencyInjection`
- Removed the now-dead `net6.0` / `net8.0` conditional `<ItemGroup>` package references in `Lamar`, `Lamar.AspNetCoreTests`, and `Lamar.AspNetCoreTests.Integration`.
- **CI workflows** (`dotnet.yml`, `publish_lamar.yml`): removed the .NET 8 SDK setup step, leaving 9.0.x + 10.0.x.

### Verification
- `dotnet build Lamar.sln -c Release` → **0 errors** (pre-existing analyzer warnings only), builds on both `net9.0` and `net10.0`.
- `dotnet pack` produces `Lamar.16.0.0.nupkg` and `Lamar.Microsoft.DependencyInjection.16.0.0.nupkg`, each containing `lib/net9.0` and `lib/net10.0`.

### ⚠️ Lamar.Diagnostics NOT included — blocked by dependency conflict
`Lamar.Diagnostics` could **not** be retargeted/published in this PR. It depends on the legacy `Oakton 6.3.0` and `JasperFx.CodeGeneration.Commands 3.4.0` packages, whose transitive constraints are mutually incompatible with the .NET 10 stack that Lamar now pulls in via `JasperFx 1.10.1`:

- `Oakton 6.3.0` → `Microsoft.Extensions.Hosting (>= 6.0.0 && < 10.0.0)`
- `Lamar` → `JasperFx 1.10.1` → `Microsoft.Extensions.Hosting (>= 10.0.0)`  ← irreconcilable
- (and similarly `JasperFx.RuntimeCompiler 3.4.0` caps `Logging.Abstractions < 9.0.0`)

Publishing `Lamar.Diagnostics` at 16.0.0 requires migrating it off `Oakton` / `JasperFx.CodeGeneration.Commands` onto the unified `JasperFx 1.x` package — a code change that should be done deliberately as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
